### PR TITLE
Add "link-args=-no-pie" automatically where apropriate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-tarpaulin"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "cargo 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Fixes #7 

These patches teach Tarpaulin to add the "-no-pie" flag where allowed and needed.

This has been tested on Ubuntu 17.04 (requires the linker flag) and Ubuntu 15.04 (rejects the linker flag).