### PR TITLE
Remove extra newline in help text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn is_dir(d: String) -> Result<(), String> {
 const CI_SERVER_HELP: &'static str = 
 "Name of service, supported services are:
 travis-ci, travis-pro, circle-ci, semaphore, jenkins and codeship.
-If you are interfacing with coveralls.io or another site you can
+If you are interfacing with coveralls.io or another site you can \
 also specify a name that they will recognise. Refer to their documentation for this.";
 
 


### PR DESCRIPTION
Clap will word wrap the help texts on a per-line basis. So the newline in the help text becomes significant in the output and you end up with this output on a standard 80-column terminal:
```
        --ciserver <SERVICE>    Name of service, supported services are:
                                travis-ci, travis-pro, circle-ci, semaphore,
                                jenkins and codeship.
                                If you are interfacing with coveralls.io or
                                another site you can
                                also specify a name that they will recognise.
                                Refer to their documentation for this.
```

Notice how there is an unnecessary line break between `you can` and `also specify`. This is the newline from the help text that has been preserved in the output.