### PR TITLE
Add a --all flag to manually turn on building a whole workspace

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,8 @@ pub struct Config {
     pub forward_signals: bool,
     /// Features to include in the target project build
     pub features: Vec<String>,
+    /// Build all packages in the workspace
+    pub all: bool,
     /// Packages to include when building the target project
     pub packages: Vec<String>,
     /// Packages to exclude from testing
@@ -112,6 +114,7 @@ impl Config {
             Some(v) => v,
             None => vec![],
         };
+        let all = args.is_present("all");
         let packages: Vec<String> = match args.values_of_lossy("packages") {
             Some(v) => v,
             None => vec![],
@@ -138,6 +141,7 @@ impl Config {
             ci_tool: ci_tool,
             forward_signals: forward,
             features: features,
+            all: all,
             packages: packages,
             exclude: exclude,
             varargs: varargs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub fn launch_tarpaulin(config: &Config) -> Result<Vec<TracerData>, i32> {
         
     let mut copt = ops::CompileOptions::default(&cargo_config, ops::CompileMode::Test); 
     copt.features = config.features.as_slice();
-    copt.spec = match ops::Packages::from_flags(workspace.is_virtual(), true, &config.exclude, &config.packages) {
+    copt.spec = match ops::Packages::from_flags(workspace.is_virtual(), config.all, &config.exclude, &config.packages) {
         Ok(spec) => spec,
         Err(e) => { 
             println!("Error getting Packages from workspace {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
                  --forward -f 'Forwards unexpected signals to test. Tarpaulin will still take signals it is expecting.'
                  --coveralls [KEY]  'Coveralls key, either the repo token, or if you're using travis use $TRAVIS_JOB_ID and specify travis-{ci|pro} in --ciserver'
                  --features [FEATURE]... 'Features to be included in the target project'
+                 --all        'Build all packages in the workspace'
                  --packages -p [PACKAGE]... 'Package id specifications for which package should be build. See cargo help pkgid for more info'
                  --exclude -e [PACKAGE]... 'Package id specifications to exclude from coverage. See cargo help pkgid for more info'")
             .args(&[


### PR DESCRIPTION
This way tarpaulin will behave more consistently with the rest of the cargo subcommands.

The previously added default to `--all` really broke my CI, as I have in my workspace a single package on which tarpaulin should be run : the others cannot be built by tarpaulin with their default feature flags require system libs that are not installed on travis (namely Mesa), forcing me to manually exclude all other packages like this:

https://github.com/Smithay/wayland-rs/blob/ecca2d54340da7afca7b364cb53da61935211de9/.travis.yml#L55