### PR TITLE
Add ( and ) to the list of chars in ignored lines.

### DIFF
--- a/src/source_analysis.rs
+++ b/src/source_analysis.rs
@@ -222,8 +222,8 @@ impl<'a> CoverageVisitor<'a> {
             for line in &l.lines {
                 let pb = PathBuf::from(self.codemap.span_to_filename(span) as String);
                 if let Some(s) = l.file.get_line(line.line_index) {
-                    // Is this one of those pointless {, } or }; only lines?
-                    if !s.chars().any(|x| !"{}[]?;\t ,".contains(x)) {
+                    // Is this one of those pointless {, } or }; or )?; only lines?
+                    if !s.chars().any(|x| !"(){}[]?;\t ,".contains(x)) {
                         self.lines.push((pb, line.line_index + 1));
                     }
                 }


### PR DESCRIPTION
Without this , lines containing only `)?;` were not ignored.

This removes around 150 lines detected as "uncovered" on wayland-rs.