### PR TITLE
Add Dockerfile for building on Docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust
+
+RUN apt-get update && apt-get install -y cmake
+
+COPY . /opt/tarpaulin/
+
+RUN cd /opt/tarpaulin/ && \
+    cargo install && \
+    rm -rf /opt/tarpaulin/ && \
+    rm -rf /usr/local/cargo/registry/cache/
+
+WORKDIR /volume
+
+CMD cargo build && cargo tarpaulin

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ COPY . /opt/tarpaulin/
 RUN cd /opt/tarpaulin/ && \
     cargo install && \
     rm -rf /opt/tarpaulin/ && \
-    rm -rf /usr/local/cargo/registry/cache/ && \
-    rm -rf /usr/local/cargo/registry/src/
+    rm -rf /usr/local/cargo/registry/
 
 WORKDIR /volume
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY . /opt/tarpaulin/
 RUN cd /opt/tarpaulin/ && \
     cargo install && \
     rm -rf /opt/tarpaulin/ && \
-    rm -rf /usr/local/cargo/registry/cache/
+    rm -rf /usr/local/cargo/registry/cache/ && \
+    rm -rf /usr/local/cargo/registry/src/
 
 WORKDIR /volume
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM rust
 
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && \
+    apt-get install -y cmake && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/tarpaulin/
 


### PR DESCRIPTION
This is the first part for #65.

You can see the image here: https://hub.docker.com/r/robinst/tarpaulin/

You can try it out in a repository where you want to calculate coverage using this command:

    docker run --security-opt seccomp=unconfined -v "$PWD:/volume" robinst/tarpaulin

If you want more options, you have to run it like this:

    docker run --security-opt seccomp=unconfined -v "$PWD:/volume" robinst/tarpaulin cargo tarpaulin --ignore-tests --out Xml

If you want to run multiple commands, you have to use a shell like this:

    docker run --security-opt seccomp=unconfined -v "$PWD:/volume" robinst/tarpaulin sh -c "cargo build && cargo tarpaulin"

After merging this (or even before), you can set up an automated build in your account using "Create Automated Build" on Docker hub:

<img width="354" alt="screen shot 2017-12-01 at 13 53 20" src="https://user-images.githubusercontent.com/16778/33465981-0f81a088-d69f-11e7-9fea-6151b42707cd.png">

You will be able to configure when it should be built automatically, e.g. only build tags or also build master. You probably want to remove automatic building of all branches.

Once that's done I can raise another PR to add the instructions to the README :).