### PR TITLE
Remove code setting up "-no-pie"

### DIFF
--- a/tests/data/proc_macro/Cargo.lock
+++ b/tests/data/proc_macro/Cargo.lock
@@ -1,0 +1,54 @@
+[[package]]
+name = "proc-macro2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "simple_project"
+version = "0.1.0"
+dependencies = [
+ "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
+"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
+"checksum serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79"
+"checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/tests/data/proc_macro/Cargo.toml
+++ b/tests/data/proc_macro/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "simple_project"
+version = "0.1.0"
+authors = ["Daniel McKenna <danielmckenna93@gmail.com>"]
+
+[dependencies]
+serde_derive = "^1.0"

--- a/tests/data/proc_macro/src/lib.rs
+++ b/tests/data/proc_macro/src/lib.rs
@@ -1,0 +1,11 @@
+#[allow(unused_imports)]
+#[macro_use]
+extern crate serde_derive;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn blah() {
+        assert_eq!(true, true, "testing");
+    }
+}

--- a/tests/line_coverage.rs
+++ b/tests/line_coverage.rs
@@ -49,3 +49,15 @@ fn simple_project_coverage() {
         }
     }
 }
+
+#[test]
+fn proc_macro_link() {
+    let mut config = Config::default();
+    config.test_timeout = Duration::from_secs(60);
+    let mut test_dir = env::current_dir().unwrap();
+    test_dir.push("tests");
+    test_dir.push("data");
+    test_dir.push("proc_macro");
+    config.manifest = test_dir.join("Cargo.toml");
+    assert!(launch_tarpaulin(&config).is_ok());
+}


### PR DESCRIPTION
These commits remove the code I added so long ago that added "-no-pie" when required. This code caused some problems, mainly with anything using proc macros. `rustc` now handles this for us, and in a better way so we no longer need this code.

A test is also included and is set to run with a normal call to `cargo test`. I ran the test both with and without the removed code to be sure that this actually fixed the issue. If you would not like this test to run by default, please let me know and I will modify the test.

I can't say I have ever been so happy to remove all of my code from a codebase before.

Fixes #23 