### PR TITLE
Aggregate results

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,6 @@ We recommend taking the minimal rust .travis.yml, installing the libssl-dev
 dependency tarpaulin has and then running Tarpaulin with the version of 
 rustc you require.
 
-The travis-install shell script will install the latest tagged release built
-on travis to your travis instance and significantly speeds up the travis 
-builds. If you want an earlier version of tarpaulin, look at the script to
-see what you need to implement and adjust accordingly or use 
-`cargo install cargo-tarpaulin` and specify the version in the arguments.
-
 For codecov.io you'll need to export CODECOV_TOKEN are instructions on this in
 the settings of your codecov project.
 
@@ -164,7 +158,7 @@ script:
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+    `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin` 
     # Uncomment the following line for coveralls.io
     # cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
 
@@ -173,6 +167,14 @@ after_success: |
     # bash <(curl -s https://codecov.io/bash)
   fi
 ```
+
+Alternative, there is the travis-install shell script will install the latest tagged 
+release built on travis to your travis instance and significantly speeds up the travis 
+builds. You can install via that script using 
+`bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)`.
+**Warning** due to the proc_macro2 dependency, the github releases are now tied
+to a specific version of rust so are no longer recommended. Instead use cargo or docker to 
+install tarpaulin.
 
 ### Docker
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,8 @@ pub fn report_coverage(config: &Config, result: &TraceMap) {
         println!("Coverage Results");
         if config.verbose {
 
+            println!();
+            println!("## Uncovered Lines:");
             for (ref key, ref value) in result.iter() {
                 let path = config.strip_project_path(key);
                 let mut uncovered_lines = vec![];
@@ -193,8 +195,9 @@ pub fn report_coverage(config: &Config, result: &TraceMap) {
                 let (groups, _) = accumulate_lines((groups, last_group), u64::max_value());
                 println!("{}: {}", path.display(), groups.join(", "));
             }
-            println!("");
+            println!();
         }
+        println!("## Tested/Total Lines");
         for file in result.files() {
             let path = config.strip_project_path(file);
             println!("{}: {}/{}", path.display(), result.covered_in_path(&file), result.coverable_in_path(&file));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,9 +151,17 @@ pub fn report_coverage(config: &Config, result: &TraceMap) {
         if config.verbose {
             for (ref key, ref value) in result.iter() {
                 let path = config.strip_project_path(key);
+                let mut uncovered_lines = vec![];
                 for v in value.iter() {
-                    println!("{}:{} - {}", path.display(), v.line, v.stats);
+                    match v.stats {
+                        traces::CoverageStat::Line(count) if count == 0 => {
+                            uncovered_lines.push(v.line);
+                        },
+                        _ => (),
+                    }
+                    // println!("{}:{} - {}", path.display(), v.line, v.stats);
                 }
+                println!("{}: {:?}", path.display(), uncovered_lines);
             }
             println!("");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ pub fn report_coverage(config: &Config, result: &TraceMap) {
         if config.verbose {
 
             println!();
-            println!("## Uncovered Lines:");
+            println!("Uncovered Lines:");
             for (ref key, ref value) in result.iter() {
                 let path = config.strip_project_path(key);
                 let mut uncovered_lines = vec![];
@@ -185,8 +185,6 @@ pub fn report_coverage(config: &Config, result: &TraceMap) {
                         },
                         _ => (),
                     }
-
-                    // println!("{}:{} - {}", path.display(), v.line, v.stats);
                 }
                 uncovered_lines.sort();
                 let (groups, last_group) =
@@ -197,7 +195,7 @@ pub fn report_coverage(config: &Config, result: &TraceMap) {
             }
             println!();
         }
-        println!("## Tested/Total Lines");
+        println!("Tested/Total Lines:");
         for file in result.files() {
             let path = config.strip_project_path(file);
             println!("{}: {}/{}", path.display(), result.covered_in_path(&file), result.coverable_in_path(&file));


### PR DESCRIPTION
This isn't a production quality implementation, it's currently just a hack for my own personal use.  In particular, there are no tests for the new code, and the output format could use some improvement.  If you're interested in merging this feature in I would be happy to clean things up.

For reference, this is what the new output format looks like for the simple example project: 

```
Coverage Results
src/lib.rs: 6
src/unused.rs: 4-6

src/lib.rs: 5/6
src/unused.rs: 0/3

55.56% coverage, 5/9 lines covered
```

Fixes #92 