### PR TITLE
Don't print a line for files that have no uncovered lines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,9 @@ pub fn report_coverage(config: &Config, result: &TraceMap) {
                     uncovered_lines.into_iter()
                     .fold((vec![], vec![]), accumulate_lines);
                 let (groups, _) = accumulate_lines((groups, last_group), u64::max_value());
-                println!("{}: {}", path.display(), groups.join(", "));
+                if ! groups.is_empty() {
+                    println!("{}: {}", path.display(), groups.join(", "));
+                }
             }
             println!();
         }


### PR DESCRIPTION
I noticed that files with no uncovered lines are still getting printed in the uncovered lines listing.  Thanks for the new release!