### PR TITLE
Cleanup trailing spaces

### DIFF
--- a/src/breakpoint.rs
+++ b/src/breakpoint.rs
@@ -9,31 +9,31 @@ const INT: u64 = 0xCC;
 
 
 /// Breakpoint construct used to monitor program execution. As tarpaulin is an
-/// automated process, this will likely have less functionality than most 
+/// automated process, this will likely have less functionality than most
 /// breakpoint implementations.
 #[derive(Debug)]
-pub struct Breakpoint { 
+pub struct Breakpoint {
     /// Program counter
     pub pc: u64,
-    /// Bottom byte of address data. 
+    /// Bottom byte of address data.
     /// This is replaced to enable the interrupt. Rest of data is never changed.
     data: u8,
-    /// Reading from memory with ptrace gives addresses aligned to bytes. 
+    /// Reading from memory with ptrace gives addresses aligned to bytes.
     /// We therefore need to know the shift to place the breakpoint in the right place
     shift: u64,
-    /// Map of the state of the breakpoint on each thread/process 
+    /// Map of the state of the breakpoint on each thread/process
     is_running: HashMap<Pid, bool>
 }
 
 impl Breakpoint {
-    /// Creates a new breakpoint for the given process and program counter. 
+    /// Creates a new breakpoint for the given process and program counter.
     pub fn new(pid:Pid, pc:u64) ->Result<Breakpoint> {
         let aligned = pc & !0x7u64;
         let data = read_address(pid, aligned)?;
         let shift = 8 * (pc - aligned);
         let data = ((data >> shift) & 0xFF) as u8;
-        
-        let mut b = Breakpoint{ 
+
+        let mut b = Breakpoint{
             pc,
             data,
             shift,
@@ -57,7 +57,7 @@ impl Breakpoint {
             write_to_address(pid, self.aligned_address(), intdata)
         }
     }
-    
+
     fn disable(&self, pid: Pid) -> Result<c_long> {
         // I require the bit fiddlin this end.
         let data = read_address(pid, self.aligned_address())?;

--- a/src/ptrace_control.rs
+++ b/src/ptrace_control.rs
@@ -10,9 +10,9 @@ const RIP: u8 = 128;
 
 pub fn trace_children(pid: Pid) -> Result<()> {
     //TODO need to check support.
-    let options: Options = Options::PTRACE_O_TRACESYSGOOD | 
-        Options::PTRACE_O_TRACEEXEC | Options::PTRACE_O_TRACEEXIT | 
-        Options::PTRACE_O_TRACECLONE | Options::PTRACE_O_TRACEFORK | 
+    let options: Options = Options::PTRACE_O_TRACESYSGOOD |
+        Options::PTRACE_O_TRACEEXEC | Options::PTRACE_O_TRACEEXIT |
+        Options::PTRACE_O_TRACECLONE | Options::PTRACE_O_TRACEFORK |
         Options::PTRACE_O_TRACEVFORK;
     setoptions(pid, options)
 }
@@ -41,7 +41,7 @@ pub fn read_address(pid: Pid, address:u64) -> Result<c_long> {
 
 #[allow(deprecated)]
 pub fn write_to_address(pid: Pid,
-                        address: u64, 
+                        address: u64,
                         data: i64) -> Result<c_long> {
     unsafe {
         ptrace(Request::PTRACE_POKEDATA, pid, address as * mut c_void, data as * mut c_void)

--- a/src/report/cobertura.rs
+++ b/src/report/cobertura.rs
@@ -13,10 +13,10 @@ use config::Config;
 
 
 fn write_header<T:Write>(writer: &mut Writer<T>, config: &Config) -> Result<usize> {
-    
+
     writer.write_event(Event::Start(BytesStart::borrowed(b"sources", b"sources".len())))?;
     writer.write_event(Event::Start(BytesStart::borrowed(b"source", b"source".len())))?;
-    
+
     let parent_folder = match config.manifest.parent() {
         Some(s) => s.to_str().unwrap_or_default(),
         None => "",
@@ -28,20 +28,20 @@ fn write_header<T:Write>(writer: &mut Writer<T>, config: &Config) -> Result<usiz
 
 
 /// Input only from single source file
-fn write_class<T:Write>(writer: &mut Writer<T>, 
-                        manifest_path: &Path, 
+fn write_class<T:Write>(writer: &mut Writer<T>,
+                        manifest_path: &Path,
                         filename: &Path,
                         coverage: &TraceMap) ->Result<usize> {
     if !coverage.is_empty() {
         let covered = coverage.covered_in_path(filename);
         let covered = (covered as f32)/(coverage.coverable_in_path(filename) as f32);
-        
+
         let tidy_filename = match filename.strip_prefix(manifest_path) {
             Ok(p) => p,
             _ => filename,
         };
         let name = filename.file_stem().unwrap_or_default().to_str().unwrap_or_default();
-        
+
         let mut class = BytesStart::owned(b"class".to_vec(), b"class".len());
         class.push_attribute(("name", name));
         class.push_attribute(("filename", tidy_filename.to_str().unwrap_or_default()));
@@ -72,7 +72,7 @@ fn write_class<T:Write>(writer: &mut Writer<T>,
 }
 
 /// Input only tracer data from a single source folder
-fn write_package<T:Write>(mut writer: &mut Writer<T>, 
+fn write_package<T:Write>(mut writer: &mut Writer<T>,
                           package: &Path,
                           manifest_path: &Path,
                           package_name: &str,
@@ -100,9 +100,9 @@ fn write_package<T:Write>(mut writer: &mut Writer<T>,
 
 pub fn export(coverage_data: &TraceMap, config: &Config) {
     let mut file = File::create("cobertura.xml").unwrap();
-    let mut writer = Writer::new(Cursor::new(Vec::new()));    
+    let mut writer = Writer::new(Cursor::new(Vec::new()));
     writer.write_event(Event::Decl(BytesDecl::new(b"1.0", None, None))).unwrap();
-    // Construct cobertura xml 
+    // Construct cobertura xml
     let line_rate = coverage_data.coverage_percentage();
     let mut cov = BytesStart::owned(b"coverage".to_vec(), b"coverage".len());
     cov.push_attribute(("line-rate", line_rate.to_string().as_ref()));
@@ -119,7 +119,7 @@ pub fn export(coverage_data: &TraceMap, config: &Config) {
     let _ = write_header(&mut writer, &config);
     // other data
     writer.write_event(Event::Start(BytesStart::borrowed(b"packages", b"packages".len()))).unwrap();
-    
+
     let mut folder_set: HashSet<&Path> = HashSet::new();
     for t in &coverage_data.files() {
         let parent = match t.parent() {

--- a/src/report/coveralls.rs
+++ b/src/report/coveralls.rs
@@ -12,18 +12,18 @@ pub fn export(coverage_data: &TraceMap, config: &Config) {
             }),
             _ => Identity::RepoToken(key.clone()),
         };
-        let mut report = CoverallsReport::new(id);        
+        let mut report = CoverallsReport::new(id);
         for file in &coverage_data.files() {
             let rel_path = config.strip_project_path(file);
             let mut lines: HashMap<usize, usize> = HashMap::new();
             let fcov = coverage_data.get_child_traces(file);
-            
+
             for c in &fcov {
                 match c.stats {
                     CoverageStat::Line(hits) => {
                         lines.insert(c.line as usize, hits as usize);
                     },
-                    _ => { 
+                    _ => {
                         println!("Support for coverage statistic not implemented or supported for coveralls.io");
                     },
                 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -4,10 +4,10 @@ use serde::Serialize;
 
 pub mod cobertura;
 pub mod coveralls;
-/// Trait for report formats to implement. 
+/// Trait for report formats to implement.
 /// Currently reports must be serializable using serde
 pub trait Report<Out: Serialize> {
     /// Export coverage report
     fn export(coverage_data: &[TracerData], config: &Config);
-    
+
 }

--- a/src/source_analysis.rs
+++ b/src/source_analysis.rs
@@ -21,7 +21,7 @@ pub enum Lines {
 /// in question as this is expected to be maintained by the user.
 #[derive(Clone, Debug)]
 pub struct LineAnalysis {
-    /// This represents lines that should be ignored in coverage 
+    /// This represents lines that should be ignored in coverage
     /// but may be identifed as coverable in the DWARF tables
     pub ignore: HashSet<Lines>,
     /// This represents lines that should be included in coverage
@@ -111,7 +111,7 @@ impl LineAnalysis {
                     true
                 };
                 if is_code && !SINGLE_LINE.is_match(line) {
-                    useful_lines.insert(i+1);    
+                    useful_lines.insert(i+1);
                 }
             }
         }
@@ -126,7 +126,7 @@ impl LineAnalysis {
     pub fn should_ignore(&self, line: usize) -> bool {
         self.ignore.contains(&Lines::Line(line)) || self.ignore.contains(&Lines::All)
     }
-    
+
     /// Adds a line to the list of lines to ignore
     fn add_to_ignore(&mut self, lines: &[usize]) {
         if !self.ignore.contains(&Lines::All) {
@@ -155,7 +155,7 @@ fn is_target_folder(entry: &DirEntry, root: &Path) -> bool {
 /// Returns a list of files and line numbers to ignore (not indexes!)
 pub fn get_line_analysis(project: &Workspace, config: &Config) -> HashMap<PathBuf, LineAnalysis> {
     let mut result: HashMap<PathBuf, LineAnalysis> = HashMap::new();
-    
+
     let mut ignored_files: HashSet<PathBuf> = HashSet::new();
 
     let walker = WalkDir::new(project.root()).into_iter();
@@ -163,14 +163,14 @@ pub fn get_line_analysis(project: &Workspace, config: &Config) -> HashMap<PathBu
                    .filter_map(|e| e.ok())
                    .filter(|e| is_source_file(e)) {
         if !ignored_files.contains(e.path()) {
-            analyse_package(e.path(), project.root(), &config, &mut result, &mut ignored_files); 
+            analyse_package(e.path(), project.root(), &config, &mut result, &mut ignored_files);
         } else {
             let mut analysis = LineAnalysis::new();
             analysis.ignore_all();
             result.insert(e.path().to_path_buf(), analysis);
             ignored_files.remove(e.path());
         }
-    } 
+    }
     for e in &ignored_files {
         let mut analysis = LineAnalysis::new();
         analysis.ignore_all();
@@ -194,7 +194,7 @@ fn analyse_lib_rs(file: &Path, result: &mut HashMap<PathBuf, LineAnalysis>) {
                     l.add_to_ignore(&[1]);
                     result.insert(file, l);
                 }
-            }   
+            }
         }
     }
 }
@@ -215,18 +215,18 @@ struct Context<'a> {
 
 
 /// Analyses a package of the target crate.
-fn analyse_package(path: &Path, 
+fn analyse_package(path: &Path,
                    root: &Path,
-                   config:&Config, 
+                   config:&Config,
                    result: &mut HashMap<PathBuf, LineAnalysis>,
                    filtered_files: &mut HashSet<PathBuf>) {
 
     if let Some(file) = path.to_str() {
-        let skip_cause_test = config.ignore_tests && 
+        let skip_cause_test = config.ignore_tests &&
                               path.starts_with(root.join("tests"));
         let skip_cause_example = path.starts_with(root.join("examples"));
         if !(skip_cause_test || skip_cause_example)  {
-            let file = File::open(file); 
+            let file = File::open(file);
             if let Ok(mut file) =  file {
                 let mut content = String::new();
                 let _ = file.read_to_string(&mut content);
@@ -306,7 +306,7 @@ fn process_items(items: &[Item], ctx: &Context, analysis: &mut LineAnalysis) -> 
                 }
             },
             _ =>{}
-        } 
+        }
     }
     res
 }
@@ -337,7 +337,7 @@ fn process_statements(stmts: &[Stmt], ctx: &Context, analysis: &mut LineAnalysis
 
 
 fn visit_mod(module: &ItemMod, analysis: &mut LineAnalysis, ctx: &Context) {
-    analysis.ignore_span(module.mod_token.0); 
+    analysis.ignore_span(module.mod_token.0);
     let mut check_insides = true;
     for attr in &module.attrs {
         if let Some(x) = attr.interpret_meta() {
@@ -375,14 +375,14 @@ fn visit_mod(module: &ItemMod, analysis: &mut LineAnalysis, ctx: &Context) {
     } else {
         // Get the file or directory name of the module
         let mut p = if let Some(parent) = ctx.file.parent() {
-            parent.join(module.ident.to_string()) 
+            parent.join(module.ident.to_string())
         } else {
             PathBuf::from(module.ident.to_string())
         };
-        if !p.exists() { 
+        if !p.exists() {
             p.set_extension("rs");
         }
-        ctx.ignore_mods.borrow_mut().insert(p);                           
+        ctx.ignore_mods.borrow_mut().insert(p);
     }
 }
 
@@ -429,7 +429,7 @@ fn visit_fn(func: &ItemFn, analysis: &mut LineAnalysis, ctx: &Context) {
         visit_generics(&func.decl.generics, analysis);
         let line_number = func.decl.fn_token.span().start().line;
         analysis.ignore.remove(&Lines::Line(line_number));
-        // Ignore multiple lines of fn decl 
+        // Ignore multiple lines of fn decl
         let decl_start = func.decl.fn_token.0.start().line+1;
         let stmts_start = func.block.span().start().line;
         let lines = (decl_start..(stmts_start+1)).collect::<Vec<_>>();
@@ -486,7 +486,7 @@ fn check_cfg_attr(attr: &Meta) -> bool {
             ignore_span = skip_match;
         }
     }
-    ignore_span 
+    ignore_span
 }
 
 
@@ -500,8 +500,8 @@ fn visit_trait(trait_item: &ItemTrait, analysis: &mut LineAnalysis, ctx: &Contex
                         analysis.cover_span(item.span(), Some(ctx.file_contents));
                         visit_generics(&i.sig.decl.generics, analysis);
                         analysis.ignore.remove(&Lines::Line(i.sig.span().start().line));
-                        
-                        // Ignore multiple lines of fn decl 
+
+                        // Ignore multiple lines of fn decl
                         let decl_start = i.sig.decl.fn_token.0.start().line+1;
                         let stmts_start = block.span().start().line;
                         let lines = (decl_start..(stmts_start+1)).collect::<Vec<_>>();
@@ -535,11 +535,11 @@ fn visit_impl(impl_blk: &ItemImpl, analysis: &mut LineAnalysis, ctx: &Context) {
                         analysis.ignore_span(i.span());
                         return
                     }
-                    
+
                     visit_generics(&i.sig.decl.generics, analysis);
                     analysis.ignore.remove(&Lines::Line(i.span().start().line));
-                    
-                    // Ignore multiple lines of fn decl 
+
+                    // Ignore multiple lines of fn decl
                     let decl_start = i.sig.decl.fn_token.0.start().line+1;
                     let stmts_start = i.block.span().start().line;
                     let lines = (decl_start..(stmts_start+1)).collect::<Vec<_>>();
@@ -792,7 +792,7 @@ fn visit_struct_expr(structure: &ExprStruct, analysis: &mut LineAnalysis) -> Sub
         };
         match first.expr {
             Expr::Lit(_) | Expr::Path(_) => {},
-            _=>{ 
+            _=>{
                 cover.insert(span.start().line);
             },
         }
@@ -812,7 +812,7 @@ fn visit_macro_call(mac: &Macro, ctx: &Context, analysis: &mut LineAnalysis) -> 
     if let Some(End(ref name)) = mac.path.segments.last() {
         let unreachable = name.ident == "unreachable";
         let standard_ignores =  name.ident == "unimplemented" || name.ident == "include";
-        let ignore_panic =  ctx.config.ignore_panics && name.ident == "panic"; 
+        let ignore_panic =  ctx.config.ignore_panics && name.ident == "panic";
         if standard_ignores || ignore_panic || unreachable {
             analysis.ignore_span(mac.span());
             skip = true;
@@ -820,7 +820,7 @@ fn visit_macro_call(mac: &Macro, ctx: &Context, analysis: &mut LineAnalysis) -> 
         if unreachable {
             return SubResult::Unreachable
         }
-        
+
     }
     if !skip {
         let lines = process_mac_args(&mac.tts);
@@ -839,7 +839,7 @@ fn process_mac_args(tokens: &TokenStream) -> HashSet<usize> {
         let t = token.span();
         match token {
             TokenTree::Literal(_) | TokenTree::Punct{..} => {},
-            _ => { 
+            _ => {
                 for i in t.start().line..(t.end().line+1) {
                     cover.insert(i);
                 }
@@ -860,7 +860,7 @@ mod tests {
         let mut la = LineAnalysis::new();
         assert!(!la.should_ignore(0));
         assert!(!la.should_ignore(10));
-        
+
         la.add_to_ignore(&[3,4, 10]);
         assert!(la.should_ignore(3));
         assert!(la.should_ignore(4));
@@ -868,7 +868,7 @@ mod tests {
         assert!(!la.should_ignore(1));
     }
 
-    #[test] 
+    #[test]
     fn filter_str_literals() {
         let mut lines = LineAnalysis::new();
         let config = Config::default();
@@ -883,7 +883,7 @@ mod tests {
         assert!(lines.ignore.len() > 1);
         assert!(lines.ignore.contains(&Lines::Line(3)));
         assert!(lines.ignore.contains(&Lines::Line(4)));
-        
+
         let ctx = Context {
             config: &config,
             file_contents: "fn test() {\nwrite(\"test\ntest\ntest\");\n}\nfn write(s:&str){}",
@@ -896,7 +896,7 @@ mod tests {
         assert!(lines.ignore.len() > 1);
         assert!(lines.ignore.contains(&Lines::Line(3)));
         assert!(lines.ignore.contains(&Lines::Line(4)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
@@ -921,12 +921,12 @@ mod tests {
         };
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
-        
+
         assert!(lines.ignore.len()> 3);
-        assert!(lines.ignore.contains(&Lines::Line(1))); 
-        assert!(lines.ignore.contains(&Lines::Line(3))); 
-        assert!(lines.ignore.contains(&Lines::Line(4))); 
-        
+        assert!(lines.ignore.contains(&Lines::Line(1)));
+        assert!(lines.ignore.contains(&Lines::Line(3)));
+        assert!(lines.ignore.contains(&Lines::Line(4)));
+
         let ctx = Context {
             config: &config,
             file_contents: "#[derive(Debug)]\npub struct Struct (\n i32\n);",
@@ -935,9 +935,9 @@ mod tests {
         };
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
-        
+
         assert!(!lines.ignore.is_empty());
-        assert!(lines.ignore.contains(&Lines::Line(3))); 
+        assert!(lines.ignore.contains(&Lines::Line(3)));
     }
 
     #[test]
@@ -952,13 +952,13 @@ mod tests {
         };
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
-        
+
         assert!(lines.ignore.len()> 3);
-        assert!(lines.ignore.contains(&Lines::Line(3))); 
-        assert!(lines.ignore.contains(&Lines::Line(4))); 
-        assert!(lines.ignore.contains(&Lines::Line(5))); 
-        assert!(lines.ignore.contains(&Lines::Line(6))); 
-        assert!(lines.ignore.contains(&Lines::Line(7))); 
+        assert!(lines.ignore.contains(&Lines::Line(3)));
+        assert!(lines.ignore.contains(&Lines::Line(4)));
+        assert!(lines.ignore.contains(&Lines::Line(5)));
+        assert!(lines.ignore.contains(&Lines::Line(6)));
+        assert!(lines.ignore.contains(&Lines::Line(7)));
     }
 
     #[test]
@@ -996,7 +996,7 @@ mod tests {
         let mut lines = LineAnalysis::new();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(!lines.ignore.contains(&Lines::Line(3)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
@@ -1007,7 +1007,7 @@ mod tests {
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.contains(&Lines::Line(1)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
@@ -1032,7 +1032,7 @@ mod tests {
         };
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
-        
+
         // Braces should be ignored so number could be higher
         assert!(lines.ignore.len() >= 1);
         assert!(lines.ignore.contains(&Lines::Line(4)));
@@ -1047,10 +1047,10 @@ mod tests {
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.len() >= 1);
         assert!(lines.ignore.contains(&Lines::Line(4)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn unreachable_match(x: u32) -> u32 {
                 match x {
                     1 => 5,
@@ -1064,7 +1064,7 @@ mod tests {
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.contains(&Lines::Line(5)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
@@ -1076,7 +1076,7 @@ mod tests {
         process_items(&parser.items, &ctx, &mut lines);
         assert!(!lines.ignore.contains(&Lines::Line(2)));
     }
-   
+
     #[test]
     fn filter_tests() {
         let config = Config::default();
@@ -1093,7 +1093,7 @@ mod tests {
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(!lines.ignore.contains(&Lines::Line(4)));
-        
+
         let ctx = Context {
             config: &igconfig,
             file_contents: "#[cfg(test)]\nmod tests {\n fn boo(){\nassert!(true);\n}\n}",
@@ -1138,7 +1138,7 @@ mod tests {
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
-            file_contents: "trait Thing { 
+            file_contents: "trait Thing {
                 #[cfg(test)]
                 fn boo(){
                     assert!(true);
@@ -1152,13 +1152,13 @@ mod tests {
         assert!(lines.ignore.contains(&Lines::Line(2)));
         assert!(lines.ignore.contains(&Lines::Line(3)));
         assert!(lines.ignore.contains(&Lines::Line(4)));
-        
+
         let config = Config::default();
 
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
-            file_contents: "trait Thing { 
+            file_contents: "trait Thing {
                 #[cfg(test)]
                 fn boo(){
                     assert!(true);
@@ -1189,11 +1189,11 @@ mod tests {
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(!lines.ignore.contains(&Lines::Line(1)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
-            file_contents: "fn boop<T>() -> T 
+            file_contents: "fn boop<T>() -> T
                 where T:Default {
                     T::default()
                 }",
@@ -1203,12 +1203,12 @@ mod tests {
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.contains(&Lines::Line(2)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
             file_contents: "trait foof {
-                fn boop<T>() -> T 
+                fn boop<T>() -> T
                 where T:Default {
                     T::default()
                 }
@@ -1254,7 +1254,7 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn unsafe_fn() {\n let x=1;\nunsafe {\nprintln!(\"{}\", x);\n}\n}",
             file: Path::new(""),
             ignore_mods: RefCell::new(HashSet::new()),
@@ -1263,10 +1263,10 @@ mod tests {
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.contains(&Lines::Line(3)));
         assert!(!lines.ignore.contains(&Lines::Line(4)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn unsafe_fn() {\n let x=1;\nunsafe {println!(\"{}\", x);}\n}",
             file: Path::new(""),
             ignore_mods: RefCell::new(HashSet::new()),
@@ -1281,7 +1281,7 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "struct GenericStruct<T>(T);
             impl<T> GenericStruct<T> {
                 fn hw(&self) {
@@ -1298,11 +1298,11 @@ mod tests {
 
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "struct GenericStruct<T>{v:Vec<T>}
             impl<T> Default for GenericStruct<T> {
                 fn default() -> Self {
-                    T { 
+                    T {
                         v: vec![],
                     }
                 }
@@ -1320,7 +1320,7 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "trait Thing {
                 fn hw(&self) {
                     println!(\"hello world\");
@@ -1341,26 +1341,26 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
-            file_contents: "struct Thing;                   
-            impl Thing{                                     
-                fn hw(&self, name: &str) {                  
-                    println!(\"hello {}\", name);           
+            config: &config,
+            file_contents: "struct Thing;
+            impl Thing{
+                fn hw(&self, name: &str) {
+                    println!(\"hello {}\", name);
                 }                                           //5
-            }                                               
-                                                            
-            fn get_name() -> String {                       
-                return \"Daniel\".to_string()               
+            }
+
+            fn get_name() -> String {
+                return \"Daniel\".to_string()
             }                                               //10
-                                                            
-            fn main() {                                     
-                let s=Thing{};                              
-                s.hw(                                       
+
+            fn main() {
+                let s=Thing{};
+                s.hw(
                     \"Paul\"                                //15
-                );                                          
-                                                            
-                s.hw(                                       
-                    &get_name()                             
+                );
+
+                s.hw(
+                    &get_name()
                 );                                          //20
             }",
             file: Path::new(""),
@@ -1377,7 +1377,7 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "use std::collections::HashMap;
             use std::{ffi::CString, os::raw::c_char};",
             file: Path::new(""),
@@ -1394,10 +1394,10 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "#[inline]
                 fn inline_func() {
-                    // I shouldn't be covered 
+                    // I shouldn't be covered
                     println!(\"I should\");
                     /*
                      None of us should
@@ -1423,12 +1423,12 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "#[cfg_attr(tarpaulin, skip)]
                 fn skipped() {
                     println!(\"Hello world\");
                 }
-            
+
             #[cfg_attr(tarpaulin, not_a_thing)]
             fn covered() {
                 println!(\"hell world\");
@@ -1443,16 +1443,16 @@ mod tests {
         assert!(lines.ignore.contains(&Lines::Line(3)));
         assert!(!lines.ignore.contains(&Lines::Line(7)));
         assert!(!lines.ignore.contains(&Lines::Line(8)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "#[cfg_attr(tarpaulin, skip)]
             mod ignore_all {
                 fn skipped() {
                     println!(\"Hello world\");
                 }
-                
+
                 #[cfg_attr(tarpaulin, not_a_thing)]
                 fn covered() {
                     println!(\"hell world\");
@@ -1476,14 +1476,14 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "#[cfg_attr(tarpaulin, skip)]
                 trait Foo {
                     fn bar() {
                         println!(\"Hello world\");
                     }
-                
-                    
+
+
                     fn not_covered() {
                         println!(\"hell world\");
                     }
@@ -1498,16 +1498,16 @@ mod tests {
         assert!(lines.ignore.contains(&Lines::Line(4)));
         assert!(lines.ignore.contains(&Lines::Line(8)));
         assert!(lines.ignore.contains(&Lines::Line(9)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "trait Foo {
                     fn bar() {
                         println!(\"Hello world\");
                     }
-                
-                    #[cfg_attr(tarpaulin, skip)] 
+
+                    #[cfg_attr(tarpaulin, skip)]
                     fn not_covered() {
                         println!(\"hell world\");
                     }
@@ -1523,22 +1523,22 @@ mod tests {
         assert!(lines.ignore.contains(&Lines::Line(7)));
         assert!(lines.ignore.contains(&Lines::Line(8)));
     }
-    
-   
+
+
     #[test]
     fn tarpaulin_skip_impl_attrs() {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "struct Foo;
                 #[cfg_attr(tarpaulin, skip)]
                 impl Foo {
                     fn bar() {
                         println!(\"Hello world\");
                     }
-                
-                    
+
+
                     fn not_covered() {
                         println!(\"hell world\");
                     }
@@ -1553,17 +1553,17 @@ mod tests {
         assert!(lines.ignore.contains(&Lines::Line(5)));
         assert!(lines.ignore.contains(&Lines::Line(9)));
         assert!(lines.ignore.contains(&Lines::Line(10)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "struct Foo;
                 impl Foo {
                     fn bar() {
                         println!(\"Hello world\");
                     }
-                
-                    
+
+
                     #[cfg_attr(tarpaulin, skip)]
                     fn not_covered() {
                         println!(\"hell world\");
@@ -1580,19 +1580,19 @@ mod tests {
         assert!(lines.ignore.contains(&Lines::Line(9)));
         assert!(lines.ignore.contains(&Lines::Line(10)));
     }
-    
-    
+
+
     #[test]
     fn filter_block_contents() {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn unreachable_match(x: u32) -> u32 {
                 match x {
                     1 => 5,
                     2 => 7,
-                    _ => { 
+                    _ => {
                         unreachable!();
                     },
                 }
@@ -1610,7 +1610,7 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn unreachable_match(x: u32) -> u32 {
                 match x {
                     1 => 5,
@@ -1624,12 +1624,12 @@ mod tests {
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(!lines.ignore.contains(&Lines::Line(5)));
-        
+
         let mut config = Config::default();
         config.ignore_panics = true;
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn unreachable_match(x: u32) -> u32 {
                 match x {
                     1 => 5,
@@ -1640,7 +1640,7 @@ mod tests {
             file: Path::new(""),
             ignore_mods: RefCell::new(HashSet::new()),
         };
-        
+
         let parser = parse_file(ctx.file_contents).unwrap();
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.contains(&Lines::Line(5)));
@@ -1651,14 +1651,14 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn block() {
                 {
                     loop {
                         for i in 1..2 {
                             if false {
                                 while let Some(x) = Some(6) {
-                                    while false { 
+                                    while false {
                                         if let Ok(y) = Ok(4) {
                                             unreachable!();
                                         }
@@ -1682,7 +1682,7 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "fn print_it(x:u32,
                 y:u32,
                 z:u32) {
@@ -1695,10 +1695,10 @@ mod tests {
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.contains(&Lines::Line(2)));
         assert!(lines.ignore.contains(&Lines::Line(3)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "struct Boo;
             impl Boo {
                 fn print_it(x:u32,
@@ -1714,7 +1714,7 @@ mod tests {
         process_items(&parser.items, &ctx, &mut lines);
         assert!(lines.ignore.contains(&Lines::Line(4)));
         assert!(lines.ignore.contains(&Lines::Line(5)));
-        
+
         let mut lines = LineAnalysis::new();
         let ctx = Context {
             config: &config,
@@ -1739,7 +1739,7 @@ mod tests {
         let config = Config::default();
         let mut lines = LineAnalysis::new();
         let ctx = Context {
-            config: &config, 
+            config: &config,
             file_contents: "enum Void {}
             fn empty_match(x: Void) -> u32 {
                 match x {

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -31,7 +31,7 @@ impl<'a> Add for &'a LogicState {
 pub enum CoverageStat {
     /// Line coverage data (whether line has been hit)
     Line(u64),
-    /// Branch coverage data (whether branch has been true and false 
+    /// Branch coverage data (whether branch has been true and false
     Branch(LogicState),
     /// Condition coverage data (each boolean subcondition true and false)
     Condition(Vec<LogicState>),
@@ -69,7 +69,7 @@ impl Display for CoverageStat {
 pub struct Trace {
     /// Line the trace is on in the file
     pub line: u64,
-    /// Optional address showing location in the test artefact 
+    /// Optional address showing location in the test artefact
     pub address: Option<u64>,
     /// Length of the instruction (useful to get entire condition/branch)
     pub length: usize,
@@ -149,12 +149,12 @@ pub struct TraceMap {
 }
 
 impl TraceMap {
-    /// Create a new TraceMap 
+    /// Create a new TraceMap
     pub fn new() -> TraceMap {
         TraceMap {
             traces: BTreeMap::new(),
         }
-    } 
+    }
 
     /// Returns true if there are no traces
     pub fn is_empty(&self) -> bool {
@@ -166,7 +166,7 @@ impl TraceMap {
         self.traces.iter()
     }
 
-    /// Merges the results of one tracemap into the current one. 
+    /// Merges the results of one tracemap into the current one.
     /// This adds records which are missing and adds the statistics gathered to
     /// existing records
     pub fn merge(&mut self, other: &TraceMap) {
@@ -213,10 +213,10 @@ impl TraceMap {
                 let mut first = true;
                 values.retain(|x| {
                     let res = x.line != *d;
-                    if !res { 
+                    if !res {
                         if first {
                             first = false;
-                            true 
+                            true
                         }else {
                             false
                         }
@@ -253,7 +253,7 @@ impl TraceMap {
             .find(|x| x.address == Some(address))
             .map(|x| *x)
     }
-    
+
     /// Gets a mutable reference to a trace at a given address
     /// Returns None if there is no trace at that address
     pub fn get_trace_mut(&mut self, address: u64) -> Option<&mut Trace> {
@@ -264,7 +264,7 @@ impl TraceMap {
         }
         None
     }
-    
+
     /// Returns true if the location described by file and line number is present
     /// in the tracemap
     pub fn contains_location(&self, file: &Path, line: u64) -> bool {
@@ -275,7 +275,7 @@ impl TraceMap {
     }
 
     /// Gets all traces below a certain path
-    pub fn get_child_traces(&self, root: &Path) -> Vec<&Trace> { 
+    pub fn get_child_traces(&self, root: &Path) -> Vec<&Trace> {
         self.traces.iter()
                    .filter(|&(ref k, _)| k.starts_with(root))
                    .flat_map(|(_, ref v)| v.iter())
@@ -320,12 +320,12 @@ impl TraceMap {
 
     /// Give the total amount of coverable points in the code. This will vary
     /// based on the statistics available for line coverage it will be total
-    /// line whereas for condition or decision it will count the number of 
+    /// line whereas for condition or decision it will count the number of
     /// conditions available
     pub fn total_coverable(&self) -> usize {
         amount_coverable(self.all_traces().as_slice())
     }
-    
+
     /// From all the coverable data return the amount covered
     pub fn total_covered(&self) -> usize {
         amount_covered(self.all_traces().as_slice())
@@ -377,16 +377,16 @@ mod tests {
         let mut t2 = TraceMap::new();
 
         let a_trace = Trace {
-            line: 1, 
-            address: Some(5), 
-            length: 0, 
+            line: 1,
+            address: Some(5),
+            length: 0,
             stats: CoverageStat::Line(1)
         };
         t1.add_trace(Path::new("file.rs"), a_trace.clone());
         t2.add_trace(Path::new("file.rs"), Trace {
-            line: 1, 
-            address: None, 
-            length: 0, 
+            line: 1,
+            address: None,
+            length: 0,
             stats: CoverageStat::Line(2)
         });
 
@@ -405,16 +405,16 @@ mod tests {
         let mut t2 = TraceMap::new();
 
         let a_trace = Trace {
-            line: 1, 
-            address: Some(5), 
-            length: 0, 
+            line: 1,
+            address: Some(5),
+            length: 0,
             stats: CoverageStat::Line(1)
         };
         t1.add_trace(Path::new("file.rs"), a_trace.clone());
         t2.add_trace(Path::new("file.rs"), Trace {
-            line: 2, 
-            address: None, 
-            length: 0, 
+            line: 2,
+            address: None,
+            length: 0,
             stats: CoverageStat::Line(2)
         });
 
@@ -432,15 +432,15 @@ mod tests {
         let mut t2 = TraceMap::new();
 
         t1.add_trace(Path::new("file.rs"), Trace {
-            line: 2, 
-            address: Some(1), 
-            length: 0, 
+            line: 2,
+            address: Some(1),
+            length: 0,
             stats: CoverageStat::Line(5)
         });
         t2.add_trace(Path::new("file.rs"), Trace {
-            line: 2, 
-            address: Some(1), 
-            length: 0, 
+            line: 2,
+            address: Some(1),
+            length: 0,
             stats: CoverageStat::Line(2)
         });
         t1.merge(&t2);


### PR DESCRIPTION
Found a lot of trailing spaces in code:

```sh
find src/ -name '*.rs' -exec grep -e ' $' {} \;
```

 Cleaned up with regex.

P.S. I have not touched the data files, but there are 3 files with the same issue.