### PR TITLE
Add an option for no default features in target build

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,6 +50,8 @@ pub struct Config {
     pub forward_signals: bool,
     /// Include all available features in target build
     pub all_features: bool,
+    /// Do not include default features in target build
+    pub no_default_features: bool,
     /// Features to include in the target project build
     pub features: Vec<String>,
     /// Build all packages in the workspace
@@ -85,6 +87,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Config {
             report_uri:         get_report_uri(args),
             forward_signals:    args.is_present("forward"),
             all_features:       args.is_present("all-features"),
+            no_default_features: args.is_present("no-default-features"),
             features:           get_list(args, "features"),
             all:                args.is_present("all"),
             packages:           get_list(args, "packages"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub fn launch_tarpaulin(config: &Config) -> Result<(TraceMap, bool), i32> {
     }
     copt.features = config.features.clone();
     copt.all_features = config.all_features;
+    copt.no_default_features = config.no_default_features;
     copt.spec = match ops::Packages::from_flags(config.all, 
                                                 config.exclude.clone(), 
                                                 config.packages.clone()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
                  --forward -f 'Forwards unexpected signals to test. Tarpaulin will still take signals it is expecting.'
                  --coveralls [KEY]  'Coveralls key, either the repo token, or if you're using travis use $TRAVIS_JOB_ID and specify travis-{ci|pro} in --ciserver'
                  --report-uri [URI] 'URI to send report to, only used if the option --coveralls is used'
+                 --no-default-features 'Do not include default features'
                  --features [FEATURE]... 'Features to be included in the target project'
                  --all-features 'Build all available features'
                  --all        'Build all packages in the workspace'


### PR DESCRIPTION
While additional features could already be specified, this adds the
ability to disable default features. Related to #25.