### PR TITLE
Docker build improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 COPY . /opt/tarpaulin/
 
 RUN cd /opt/tarpaulin/ && \
-    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install && \
+    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --path . && \
     rm -rf /opt/tarpaulin/ && \
     rm -rf /usr/local/cargo/registry/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
 COPY . /opt/tarpaulin/
 
 RUN cd /opt/tarpaulin/ && \
+    sed -i -e 's/^\(^.*publish-lockfile.*$\)/#\1/' Cargo.toml && \
     RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --path . && \
     rm -rf /opt/tarpaulin/ && \
     rm -rf /usr/local/cargo/registry/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 COPY . /opt/tarpaulin/
 
 RUN cd /opt/tarpaulin/ && \
-    cargo install && \
+    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install && \
     rm -rf /opt/tarpaulin/ && \
     rm -rf /usr/local/cargo/registry/
 

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -7,7 +7,7 @@ RUN apt-get update && \
 COPY . /opt/tarpaulin/
 
 RUN cd /opt/tarpaulin/ && \
-    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install && \
+    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --path . && \
     rm -rf /opt/tarpaulin/ && \
     rm -rf /usr/local/cargo/registry/
 


### PR DESCRIPTION
* enable procmacro2_semver_exempt for stable like for experimental
* fix cargo install for Rust 2018 edition applications
* enable tarpaulin build on stable channel by workaround: disable feature "publish-lockfile" during the build