### PR TITLE
Implement `--release` option.

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -66,6 +66,8 @@ pub struct Config {
     pub varargs: Vec<String>,
     /// Duration to wait before a timeout occurs
     pub test_timeout: Duration,
+    /// Build in release mode
+    pub release: bool,
 }
 
 impl<'a> From<&'a ArgMatches<'a>> for Config {
@@ -95,6 +97,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Config {
             excluded_files:     get_excluded(args),
             varargs:            get_list(args, "args"),
             test_timeout:       get_timeout(args),
+            release:            args.is_present("release"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,10 +178,9 @@ pub fn launch_tarpaulin(config: &Config) -> Result<(TraceMap, bool), RunError> {
 
 fn setup_environment(config: &Config) {
     let rustflags = "RUSTFLAGS";
-    let mut value = " -C relocation-model=dynamic-no-pic -C link-dead-code -C opt-level=0 ".to_string();
-    let mut value = " -C relocation-model=dynamic-no-pic -C link-dead-code -C debuginfo=2 ".to_string();
+    let mut value = " -C relocation-model=dynamic-no-pic -C link-dead-code -C opt-level=0 -C debuginfo=2 ".to_string();
     if config.release {
-        value = format!("{}-C opt-level=0 -C debug-assertions=off ", value);
+        value = format!("{}-C debug-assertions=off ", value);
     }
     if let Ok(vtemp) = env::var(rustflags) {
         value.push_str(vtemp.as_ref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub fn launch_tarpaulin(config: &Config) -> Result<(TraceMap, bool), RunError> {
             RunError::Manifest
         })?;
     
-    setup_environment();
+    setup_environment(&config);
     
     let mut copt = ops::CompileOptions::new(&cargo_config, CompileMode::Test)
         .map_err(|_| RunError::Cargo)?;
@@ -114,6 +114,7 @@ pub fn launch_tarpaulin(config: &Config) -> Result<(TraceMap, bool), RunError> {
     copt.features = config.features.clone();
     copt.all_features = config.all_features;
     copt.no_default_features = config.no_default_features;
+    copt.build_config.release = config.release;
     copt.spec = match ops::Packages::from_flags(config.all, 
                                                 config.exclude.clone(), 
                                                 config.packages.clone()) {
@@ -175,9 +176,13 @@ pub fn launch_tarpaulin(config: &Config) -> Result<(TraceMap, bool), RunError> {
 }
 
 
-fn setup_environment() {
+fn setup_environment(config: &Config) {
     let rustflags = "RUSTFLAGS";
     let mut value = " -C relocation-model=dynamic-no-pic -C link-dead-code -C opt-level=0 ".to_string();
+    let mut value = " -C relocation-model=dynamic-no-pic -C link-dead-code -C debuginfo=2 ".to_string();
+    if config.release {
+        value = format!("{}-C opt-level=0 -C debug-assertions=off ", value);
+    }
     if let Ok(vtemp) = env::var(rustflags) {
         value.push_str(vtemp.as_ref());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,8 @@ fn main() -> Result<(), RunError> {
                  --packages -p [PACKAGE]... 'Package id specifications for which package should be build. See cargo help pkgid for more info'
                  --exclude -e [PACKAGE]... 'Package id specifications to exclude from coverage. See cargo help pkgid for more info'
                  --exclude-files [FILE]... 'Exclude given files from coverage results has * wildcard'
-                 --timeout -t [SECONDS] 'Integer for the maximum time in seconds without response from test before timeout (default is 1 minute).'")
+                 --timeout -t [SECONDS] 'Integer for the maximum time in seconds without response from test before timeout (default is 1 minute).'
+                 --release   'Build tests in release mode. Will deactivate optimizations.'")
             .args(&[
                 Arg::from_usage("--out -o [FMT]   'Output format of coverage report'")
                     .possible_values(&OutputFile::variants())

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), RunError> {
                  --exclude -e [PACKAGE]... 'Package id specifications to exclude from coverage. See cargo help pkgid for more info'
                  --exclude-files [FILE]... 'Exclude given files from coverage results has * wildcard'
                  --timeout -t [SECONDS] 'Integer for the maximum time in seconds without response from test before timeout (default is 1 minute).'
-                 --release   'Build tests in release mode. Will deactivate optimizations.'")
+                 --release   'Build in release mode.'")
             .args(&[
                 Arg::from_usage("--out -o [FMT]   'Output format of coverage report'")
                     .possible_values(&OutputFile::variants())


### PR DESCRIPTION
After some trial and error it finally worked.
Fixes #181.

**Questions**
- Instead of `env::var(rustflags)` we should use `build_config.extra_rustc_args` or `build_config.extra_rustc_env`. But I couldn't figure out how they work, I don't consider important for that PR.
- I added `-C debuginfo=2` to all kind of builds, I assume that is not going to have any unintentional effects?