### PR TITLE
Flip around `--skip-clean` and make it `--force-clean`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ output correctly reports the lines the test hits.
 ```text
 cargo tarpaulin -v
 Running Tarpaulin
-Cleaning project
 Building project
    Compiling simple_project v0.1.0 (/home/xd009642/code/rust/tarpaulin/tests/data/simple_project)
     Finished dev [unoptimized + debuginfo] target(s) in 0.31s                                            

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,8 +25,8 @@ pub struct Config {
     pub ignore_tests: bool,
     /// Ignore panic macros in code.
     pub ignore_panics: bool,
-    /// Flag to skip the clean step when preparing the target project
-    pub skip_clean: bool,
+    /// Flag to add a clean step when preparing the target project
+    pub force_clean: bool,
     /// Verbose flag for printing information to the user
     pub verbose: bool,
     /// Flag to count hits in coverage
@@ -78,7 +78,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Config {
             run_ignored:        args.is_present("ignored"),
             ignore_tests:       args.is_present("ignore-tests"),
             ignore_panics:      args.is_present("ignore-panics"),
-            skip_clean:         args.is_present("skip-clean"),
+            force_clean:        args.is_present("force-clean"),
             verbose:            args.is_present("verbose"),
             count:              args.is_present("count"),
             line_coverage:      get_line_cov(args),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub fn launch_tarpaulin(config: &Config) -> Result<(TraceMap, bool), RunError> {
     if config.verbose {
         println!("Running Tarpaulin");
     }
-    if !config.skip_clean {
+    if config.force_clean {
         if config.verbose {
             println!("Cleaning project");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), RunError> {
                  --count   'Counts the number of hits during coverage'
                  --ignored -i 'Run ignored tests as well'
                  --line -l    'Line coverage'
-                 --skip-clean 'Skips the clean stage to reduce build times, may affect coverage results'
+                 --force-clean 'Adds a clean stage to work around cargo bugs that may affect coverage results'
                  --branch -b  'Branch coverage: NOT IMPLEMENTED'
                  --forward -f 'Forwards unexpected signals to test. Tarpaulin will still take signals it is expecting.'
                  --coveralls [KEY]  'Coveralls key, either the repo token, or if you're using travis use $TRAVIS_JOB_ID and specify travis-{ci|pro} in --ciserver'


### PR DESCRIPTION
I noticed that changing `RUSTFLAGS` should always result into a complete rebuild from scratch by cargo.
Anything else should be considered a bug by cargo.

**Questions**
- `Adds a clean stage to work around cargo bugs that may affect coverage results` is that fine or is that too much?
- `--force-clean` is fine? Maybe `--clean` or `--add-clean-stage`? (these are horrible suggestions I know)