### PR TITLE
Upgrade cargo to allow new manifest features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ publish-lockfile = true
 name = "cargo-tarpaulin"
 
 [dependencies]
-cargo = "0.31"
+cargo = "0.32"
 clap = "2.31.2"
 coveralls-api = "0.3.3"
 fallible-iterator = "0.1.4"


### PR DESCRIPTION
This fixes "unable to get packages from source" errors when a dependency
uses 2018 edition features such as dependency renaming: https://github.com/rust-lang/cargo/issues/5653