### PR TITLE
properly visit test functions

### DIFF
--- a/src/source_analysis.rs
+++ b/src/source_analysis.rs
@@ -416,10 +416,8 @@ fn visit_fn(func: &ItemFn, analysis: &mut LineAnalysis, ctx: &Context) {
     }
     if ignore_span {
         analysis.ignore_span(func.span());
-    } else if test_func {
-        if ctx.config.ignore_tests || (ignored_attr && !ctx.config.run_ignored) {
-            analysis.ignore_span(func.span());
-        }
+    } else if test_func &&( if ctx.config.ignore_tests || (ignored_attr && !ctx.config.run_ignored)) {
+        analysis.ignore_span(func.span());
     } else {
         if is_inline {
             // We need to force cover!


### PR DESCRIPTION
Test functions were not properly processed. This meant that flags such as `--ignore-panics` would not be applied leaving lines marked as uncovered in the test functions.
