### PR TITLE
Collect git info for coveralls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gimli 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ serde_json = "1.0"
 syn = { version = "0.15.23", features = ["full"]}
 void = "1.0"
 walkdir = "2.2.5"
+git2 = "0.7"

--- a/src/report/coveralls.rs
+++ b/src/report/coveralls.rs
@@ -2,8 +2,55 @@ use crate::config::Config;
 use crate::errors::RunError;
 use crate::traces::{CoverageStat, TraceMap};
 use coveralls_api::*;
-use log::info;
+use log::{info, warn};
 use std::collections::HashMap;
+use std::path::Path;
+
+fn get_git_info(manifest_path: &Path) -> Result<GitInfo, String> {
+    let dir_path = manifest_path
+        .parent()
+        .ok_or_else(|| format!("failed to get parent for path: {}", manifest_path.display()))?;
+    let repo = git2::Repository::discover(dir_path).map_err(|err| {
+        format!(
+            "failed to open git repository: {}: {}",
+            dir_path.display(),
+            err
+        )
+    })?;
+
+    let head = repo
+        .head()
+        .map_err(|err| format!("failed to get repository head: {}", err))?;
+    let branch = git2::Branch::wrap(head);
+    let branch_name = branch
+        .name()
+        .map_err(|err| format!("failed to get branch name: {}", err))?;
+    let get_string = |data: Option<&str>| match data {
+        Some(str) => Ok(str.to_string()),
+        None => Err("string is not valid utf-8".to_string()),
+    };
+    let branch_name = get_string(branch_name)?;
+    let commit = repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .map_err(|err| format!("failed to get commit: {}", err))?;
+
+    let author = commit.author();
+    let committer = commit.committer();
+    Ok(GitInfo {
+        head: Head {
+            id: commit.id().to_string(),
+            author_name: get_string(author.name())?,
+            author_email: get_string(author.email())?,
+            committer_name: get_string(committer.name())?,
+            committer_email: get_string(committer.email())?,
+            message: get_string(commit.message())?,
+        },
+        branch: branch_name,
+        remotes: Vec::new(),
+    })
+}
 
 pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
     if let Some(ref key) = config.coveralls {
@@ -33,6 +80,14 @@ pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError>
             if let Ok(source) = Source::new(&rel_path, file, &lines, &None, false) {
                 report.add_source(source);
             }
+        }
+
+        match get_git_info(&config.manifest) {
+            Ok(git_info) => {
+                report.set_detailed_git_info(git_info);
+                info!("Git info collected");
+            }
+            Err(err) => warn!("Failed to collect git info: {}", err),
         }
 
         let res = match config.report_uri {


### PR DESCRIPTION
Sends information about current commit and branch to coveralls.io, allowing it to display source code properly.