### PR TITLE
Make tests pathing relative to Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ autotests = false
 [[bin]]
 name = "cargo-tarpaulin"
 
+[[test]]
+name = "integration"
+path = "tests/mod.rs"
+
 [dependencies]
 cargo = "0.34"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools"]
 keywords = ["cargo", "cargo-subcommand", "testing"]
 #publish-lockfile = true
 edition = "2018"
+autotests = false
 
 [[bin]]
 name = "cargo-tarpaulin"

--- a/tests/doc_coverage.rs
+++ b/tests/doc_coverage.rs
@@ -1,18 +1,15 @@
 use cargo_tarpaulin::config::{Config, RunType};
 use cargo_tarpaulin::launch_tarpaulin;
 use std::env;
-use std::path::PathBuf;
 use std::time::Duration;
+use utils::get_test_path;
 
 #[test]
 fn doc_test_coverage() {
     let mut config = Config::default();
     config.verbose = true;
     config.test_timeout = Duration::from_secs(60);
-    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    test_dir.push("tests");
-    test_dir.push("data");
-    test_dir.push("doc_coverage");
+    let test_dir = get_test_path("doc_coverage");
     env::set_current_dir(&test_dir).unwrap();
     config.manifest = test_dir;
     config.manifest.push("Cargo.toml");

--- a/tests/doc_coverage.rs
+++ b/tests/doc_coverage.rs
@@ -1,6 +1,7 @@
 use cargo_tarpaulin::config::{Config, RunType};
 use cargo_tarpaulin::launch_tarpaulin;
 use std::env;
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[test]
@@ -8,12 +9,12 @@ fn doc_test_coverage() {
     let mut config = Config::default();
     config.verbose = true;
     config.test_timeout = Duration::from_secs(60);
-    let mut test_dir = env::current_dir().unwrap();
+    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     test_dir.push("tests");
     test_dir.push("data");
     test_dir.push("doc_coverage");
-    env::set_current_dir(test_dir.clone()).unwrap();
-    config.manifest = test_dir.clone();
+    env::set_current_dir(&test_dir).unwrap();
+    config.manifest = test_dir;
     config.manifest.push("Cargo.toml");
 
     config.run_types = vec![RunType::Doctests];

--- a/tests/doc_coverage.rs
+++ b/tests/doc_coverage.rs
@@ -1,8 +1,8 @@
+use crate::utils::get_test_path;
 use cargo_tarpaulin::config::{Config, RunType};
 use cargo_tarpaulin::launch_tarpaulin;
 use std::env;
 use std::time::Duration;
-use utils::get_test_path;
 
 #[test]
 fn doc_test_coverage() {

--- a/tests/line_coverage.rs
+++ b/tests/line_coverage.rs
@@ -1,9 +1,9 @@
+use crate::utils::get_test_path;
 use cargo_tarpaulin::config::Config;
 use cargo_tarpaulin::launch_tarpaulin;
 use cargo_tarpaulin::traces::CoverageStat;
 use std::env;
 use std::time::Duration;
-use utils::get_test_path;
 
 #[test]
 fn simple_project_coverage() {

--- a/tests/line_coverage.rs
+++ b/tests/line_coverage.rs
@@ -2,6 +2,7 @@ use cargo_tarpaulin::config::Config;
 use cargo_tarpaulin::launch_tarpaulin;
 use cargo_tarpaulin::traces::CoverageStat;
 use std::env;
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[test]
@@ -10,11 +11,11 @@ fn simple_project_coverage() {
     config.verbose = true;
     config.test_timeout = Duration::from_secs(60);
     let restore_dir = env::current_dir().unwrap();
-    let mut test_dir = env::current_dir().unwrap();
+    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     test_dir.push("tests");
     test_dir.push("data");
     test_dir.push("simple_project");
-    env::set_current_dir(test_dir.clone()).unwrap();
+    env::set_current_dir(&test_dir).unwrap();
     config.manifest = test_dir.clone();
     config.manifest.push("Cargo.toml");
 

--- a/tests/line_coverage.rs
+++ b/tests/line_coverage.rs
@@ -2,8 +2,8 @@ use cargo_tarpaulin::config::Config;
 use cargo_tarpaulin::launch_tarpaulin;
 use cargo_tarpaulin::traces::CoverageStat;
 use std::env;
-use std::path::PathBuf;
 use std::time::Duration;
+use utils::get_test_path;
 
 #[test]
 fn simple_project_coverage() {
@@ -11,10 +11,7 @@ fn simple_project_coverage() {
     config.verbose = true;
     config.test_timeout = Duration::from_secs(60);
     let restore_dir = env::current_dir().unwrap();
-    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    test_dir.push("tests");
-    test_dir.push("data");
-    test_dir.push("simple_project");
+    let test_dir = get_test_path("simple_project");
     env::set_current_dir(&test_dir).unwrap();
     config.manifest = test_dir.clone();
     config.manifest.push("Cargo.toml");

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,8 +1,8 @@
+use crate::utils::get_test_path;
 use cargo_tarpaulin::config::Config;
 use cargo_tarpaulin::launch_tarpaulin;
 use std::env;
 use std::time::Duration;
-use utils::get_test_path;
 
 mod line_coverage;
 mod doc_coverage;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,18 +1,19 @@
 use cargo_tarpaulin::config::Config;
 use cargo_tarpaulin::launch_tarpaulin;
 use std::env;
-use std::path::PathBuf;
 use std::time::Duration;
+use utils::get_test_path;
+
+mod line_coverage;
+mod doc_coverage;
+mod utils;
 
 pub fn check_percentage(project_name: &str, minimum_coverage: f64, has_lines: bool) {
     let mut config = Config::default();
     config.verbose = true;
     config.test_timeout = Duration::from_secs(60);
     let restore_dir = env::current_dir().unwrap();
-    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    test_dir.push("tests");
-    test_dir.push("data");
-    test_dir.push(project_name);
+    let test_dir = get_test_path(project_name);
     env::set_current_dir(&test_dir).unwrap();
     config.manifest = test_dir;
     config.manifest.push("Cargo.toml");
@@ -37,10 +38,7 @@ fn incorrect_manifest_path() {
 fn proc_macro_link() {
     let mut config = Config::default();
     config.test_timeout = Duration::from_secs(60);
-    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    test_dir.push("tests");
-    test_dir.push("data");
-    test_dir.push("proc_macro");
+    let test_dir = get_test_path("proc_macro");
     config.manifest = test_dir.join("Cargo.toml");
     assert!(launch_tarpaulin(&config).is_ok());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,7 @@
 use cargo_tarpaulin::config::Config;
 use cargo_tarpaulin::launch_tarpaulin;
 use std::env;
+use std::path::PathBuf;
 use std::time::Duration;
 
 pub fn check_percentage(project_name: &str, minimum_coverage: f64, has_lines: bool) {
@@ -8,12 +9,12 @@ pub fn check_percentage(project_name: &str, minimum_coverage: f64, has_lines: bo
     config.verbose = true;
     config.test_timeout = Duration::from_secs(60);
     let restore_dir = env::current_dir().unwrap();
-    let mut test_dir = env::current_dir().unwrap();
+    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     test_dir.push("tests");
     test_dir.push("data");
     test_dir.push(project_name);
-    env::set_current_dir(test_dir.clone()).unwrap();
-    config.manifest = test_dir.clone();
+    env::set_current_dir(&test_dir).unwrap();
+    config.manifest = test_dir;
     config.manifest.push("Cargo.toml");
 
     let (res, _) = launch_tarpaulin(&config).unwrap();
@@ -36,7 +37,7 @@ fn incorrect_manifest_path() {
 fn proc_macro_link() {
     let mut config = Config::default();
     config.test_timeout = Duration::from_secs(60);
-    let mut test_dir = env::current_dir().unwrap();
+    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     test_dir.push("tests");
     test_dir.push("data");
     test_dir.push("proc_macro");

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,10 @@
+use std::env;
+use std::path::PathBuf;
+
+pub(crate) fn get_test_path(test_dir_name: &str) -> PathBuf {
+    let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    test_dir.push("tests");
+    test_dir.push("data");
+    test_dir.push(test_dir_name);
+    test_dir
+}


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
On my system(Ubuntu 16 in WSL), tests were failing because the test directory paths were being built incorrectly. For instance: `tarpaulin/tests/data/ifelse/tests/data/proc_macro/Cargo.toml` was one. Instead, paths should be built relative to the `CARGO_MANIFEST_DIR` envvar which Cargo sets and is the location of your Cargo manifest. As a byproduct, this also lets you run `cargo test` in other directories (ie the test dir).