### PR TITLE
Custom formatter for serde_json to escape HTML specific characters

### DIFF
--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use crate::errors::*;
 use crate::traces::{Trace, TraceMap};
+use crate::report::safe_json;
 use serde::Serialize;
 use std::fs::{read_to_string, File};
 use std::io::Write;
@@ -54,7 +55,7 @@ pub fn export(coverage_data: &TraceMap, _config: &Config) -> Result<(), RunError
         }
     };
 
-    let report_json = match serde_json::to_string(&report) {
+    let report_json = match safe_json::to_string_safe(&report) {
         Ok(k) => k,
         Err(e) => {
             return Err(RunError::Html(format!(

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::test_loader::TracerData;
 use serde::Serialize;
 
+mod safe_json;
 pub mod cobertura;
 pub mod coveralls;
 pub mod html;

--- a/src/report/safe_json.rs
+++ b/src/report/safe_json.rs
@@ -1,0 +1,79 @@
+use std::default::Default;
+use std::io;
+use serde_json::ser::CharEscape;
+use serde_json::ser::CompactFormatter;
+
+struct SafeFormatter(CompactFormatter);
+
+impl Default for SafeFormatter {
+    fn default() -> Self {
+        SafeFormatter(CompactFormatter)
+    }
+}
+
+impl serde_json::ser::Formatter for SafeFormatter {
+    fn write_string_fragment<W: ?Sized>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut start = 0;
+
+        for (i, ch) in fragment.chars().enumerate() {
+            let escape = match ch {
+                '<' | '>' | '&' => CharEscape::AsciiControl(ch as u8),
+                _ => continue,
+            };
+
+            if start < i {
+                self.0.write_string_fragment(writer, &fragment[start..i])?;
+            }
+
+            self.write_char_escape(writer, escape)?;
+
+            start = i + 1;
+        }
+
+        if start < fragment.len() {
+            self.0.write_string_fragment(writer, &fragment[start..])?;
+        }
+        Ok(())
+    }
+}
+
+pub fn to_string_safe<T: serde::Serialize + ?Sized>(value: &T) -> Result<String, String> {
+    let mut writer = Vec::new();
+    let mut ser = serde_json::Serializer::with_formatter(&mut writer, SafeFormatter::default());
+    value.serialize(&mut ser).map_err(|e| e.to_string())?;
+    let string = String::from_utf8(writer).map_err(|e| e.to_string())?;
+    Ok(string)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{self, json};
+    use super::*;
+
+    #[test]
+    fn test_json_without_html() {
+        let x = json!({
+            "a": 1,
+            "b": "c",
+            "d": "text with \"quotes\" inside",
+        });
+        assert_eq!(to_string_safe(&x).unwrap(), serde_json::to_string(&x).unwrap());
+    }
+
+    #[test]
+    fn test_json_with_html() {
+        let x = json!({
+            "a": 1,
+            "b": "c",
+            "d": "text with \"quotes\" inside",
+            "h": "some <script>alert(\"Alert\")</script> html",
+        });
+        assert_eq!(
+            to_string_safe(&x).unwrap().as_str(),
+            r#"{"a":1,"b":"c","d":"text with \"quotes\" inside","h":"some \u003cscript\u003ealert(\"Alert\")\u003c/script\u003e html"}"#
+        );
+    }
+}


### PR DESCRIPTION
It could happen that measured code contains HTML text ([like this](https://github.com/xd009642/tarpaulin/blob/master/src/report/html.rs#L67-L80)) with `</script>` tag in it. In such situation HTML report doesn't work in browser. So, characters `<`, `>`, and '&' should also be escaped in JSON.

Serde_json allows to specify custom formatter, so this PR wraps default one and adds escape for additional characters.