### PR TITLE
Fix readme Docker commands for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Tarpaulin has builds deployed to [docker-hub](https://hub.docker.com/r/xd009642/
 to run Tarpaulin on any system that has Docker, run this in your project directory:
 
 ```text
-docker run --security-opt seccomp=unconfined -v "$PWD:/volume" xd009642/tarpaulin
+docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin
 ```
 
 This builds your project inside Docker and runs Tarpaulin without any arguments. There are
@@ -186,14 +186,14 @@ versions after 0.5.6 will have the latest release built with the rust stable and
 compilers. To get the latest development version built with rustc-nightly run the following:
 
 ```text
-docker run --security-opt seccomp=unconfined -v "$PWD:/volume" xd009642/tarpaulin:develop-nightly
+docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:develop-nightly
 ```
 
 Note that the build might fail if the Docker image doesn't contain any necessary
 dependencies. In that case, you can install dependencies before, like this:
 
 ```text
-docker run --security-opt seccomp=unconfined -v "$PWD:/volume" xd009642/tarpaulin sh -c "apt-get install xxx && cargo tarpaulin"
+docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin sh -c "apt-get install xxx && cargo tarpaulin"
 ```
 
 ## Extending Tarpaulin.


### PR DESCRIPTION
A very minor quality of life improvement: the readme's Docker commands can almost be copy/pasted into a PowerShell prompt, but `$PWD:` needs to be `${PWD}:`.