### PR TITLE
calculate relative paths to base_dir (env::current_dir(), or root arg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ file.
 ## [Unreleased]
 ### Added
 - Created `CHANGELOG.md`
+- Add --manifest-path option
 
 ### Changed
+- Ignore lines containing "}else{"
+- Use relative file paths to base_dir (env::current_dir() or --root option if set)
 
 ### Removed
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@ pub use self::types::*;
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use std::env;
 
 use clap::ArgMatches;
 use coveralls_api::CiService;
@@ -17,6 +18,8 @@ mod types;
 pub struct Config {
     /// Path to the projects cargo manifest
     pub manifest: PathBuf,
+    /// Path to the projects cargo manifest
+    pub root: Option<String>,
     /// Types of tests for tarpaulin to collect coverage on
     pub run_types: Vec<RunType>,
     /// Flag to also run tests with the ignored attribute
@@ -77,6 +80,7 @@ impl Default for Config {
         Config {
             run_types: vec![RunType::Tests],
             manifest: Default::default(),
+            root: Default::default(),
             run_ignored: false,
             ignore_tests: false,
             ignore_panics: false,
@@ -111,6 +115,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Config {
         let verbose = args.is_present("verbose") || debug;
         Config {
             manifest: get_manifest(args),
+            root: get_root(args),
             run_types: get_run_types(args),
             run_ignored: args.is_present("ignored"),
             ignore_tests: args.is_present("ignore-tests"),
@@ -148,23 +153,39 @@ impl Config {
 
     #[inline]
     pub fn exclude_path(&self, path: &Path) -> bool {
-        let project = self.strip_project_path(path);
+        let project = self.strip_base_dir(path);
 
         self.excluded_files
             .iter()
             .any(|x| x.is_match(project.to_str().unwrap_or("")))
     }
 
-    /// Strips the directory the project manifest is in from the path.
-    /// Provides a nicer path for printing to the user.
+    ///
+    /// returns the relative path from the base_dir
+    /// uses root if set, else env::current_dir()
     ///
     #[inline]
-    pub fn strip_project_path(&self, path: &Path) -> PathBuf {
-        self.manifest
-            .parent()
-            .and_then(|x| path_relative_from(path, x))
-            .unwrap_or_else(|| path.to_path_buf())
+    pub fn get_base_dir(&self) -> PathBuf {
+        if let Some(root) = &self.root {
+            if Path::new(root).is_absolute() {
+                PathBuf::from(root)
+            }else{
+                let base_dir = env::current_dir().unwrap();
+                base_dir.join(root).canonicalize().unwrap()
+            }
+        }else{
+            env::current_dir().unwrap()
+        }
     }
+
+    /// returns the relative path from the base_dir
+    ///
+    #[inline]
+    pub fn strip_base_dir(&self, path: &Path) -> PathBuf {
+        path_relative_from(path, &self.get_base_dir())
+        .unwrap_or_else(|| path.to_path_buf())
+    }
+
 }
 
 /// Gets the relative path from one directory to another, if it exists.

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -26,6 +26,10 @@ pub(super) fn get_branch_cov(args: &ArgMatches) -> bool {
 }
 
 pub(super) fn get_manifest(args: &ArgMatches) -> PathBuf {
+    if let Some(path) = args.value_of("manifest-path") {
+        return PathBuf::from(path);
+    }
+
     let mut manifest = env::current_dir().unwrap();
 
     if let Some(path) = args.value_of("root") {
@@ -34,6 +38,10 @@ pub(super) fn get_manifest(args: &ArgMatches) -> PathBuf {
 
     manifest.push("Cargo.toml");
     manifest.canonicalize().unwrap_or(manifest)
+}
+
+pub(super) fn get_root(args: &ArgMatches) -> Option<String> {
+    args.value_of("root").map(ToString::to_string)
 }
 
 pub(super) fn get_ci(args: &ArgMatches) -> Option<CiService> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunErro
         if config.verbose {
             println!("|| Uncovered Lines:");
             for (ref key, ref value) in result.iter() {
-                let path = config.strip_project_path(key);
+                let path = config.strip_base_dir(key);
                 let mut uncovered_lines = vec![];
                 for v in value.iter() {
                     match v.stats {
@@ -306,7 +306,7 @@ pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunErro
         }
         println!("|| Tested/Total Lines:");
         for file in result.files() {
-            let path = config.strip_project_path(file);
+            let path = config.strip_base_dir(file);
             println!(
                 "|| {}: {}/{}",
                 path.display(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ fn main() -> Result<(), String> {
                     .multiple(true),
                 Arg::from_usage("--root -r [DIR]  'Root directory containing Cargo.toml to use'")
                     .validator(is_dir),
+                Arg::from_usage("--manifest-path [PATH] 'Path to Cargo.toml'"),
                 Arg::from_usage("--ciserver [SERVICE] 'CI server being used, if unspecified tarpaulin may automatically infer for coveralls uploads'")
                     .help(CI_SERVER_HELP),
                 Arg::with_name("args")

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> Result<(), String> {
                 Arg::from_usage("--run-types [TYPE] 'Type of the coverage run'")
                     .possible_values(&RunType::variants())
                     .multiple(true),
-                Arg::from_usage("--root -r [DIR]  'Root directory containing Cargo.toml to use'")
+                Arg::from_usage("--root -r [DIR]  'Calculates relative paths to root directory. If --manifest-path isn't specified it will look for a Cargo.toml in root'")
                     .validator(is_dir),
                 Arg::from_usage("--manifest-path [PATH] 'Path to Cargo.toml'"),
                 Arg::from_usage("--ciserver [SERVICE] 'CI server being used, if unspecified tarpaulin may automatically infer for coveralls uploads'")

--- a/src/report/coveralls.rs
+++ b/src/report/coveralls.rs
@@ -84,7 +84,7 @@ pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError>
 
         let mut report = CoverallsReport::new(id);
         for file in &coverage_data.files() {
-            let rel_path = config.strip_project_path(file);
+            let rel_path = config.strip_base_dir(file);
             let mut lines: HashMap<usize, usize> = HashMap::new();
             let fcov = coverage_data.get_child_traces(file);
 

--- a/src/source_analysis.rs
+++ b/src/source_analysis.rs
@@ -209,10 +209,7 @@ pub fn get_line_analysis(project: &Workspace, config: &Config) -> HashMap<PathBu
 pub fn debug_printout(result: &HashMap<PathBuf, LineAnalysis>, config: &Config) {
     if config.debug {
         for (ref path, ref analysis) in result {
-            trace!(
-                "Source analysis for {}",
-                config.strip_project_path(path).display()
-            );
+            trace!("Source analysis for {}", config.strip_base_dir(path).display());
             let mut lines = Vec::new();
             for l in &analysis.ignore {
                 match l {
@@ -338,6 +335,18 @@ fn find_ignorable_lines(content: &str, analysis: &mut LineAnalysis) {
         .lines()
         .enumerate()
         .filter(|&(_, x)| !x.chars().any(|x| !"(){}[]?;\t ,".contains(x)))
+        .map(|(i, _)| i + 1)
+        .collect::<Vec<usize>>();
+    analysis.add_to_ignore(&lines);
+
+    let lines = content
+        .lines()
+        .enumerate()
+        .filter(|&(_, x)| {
+            let mut x = x.to_string();
+            x.retain(|c| !c.is_whitespace());
+            x == "}else{"
+        })
         .map(|(i, _)| i + 1)
         .collect::<Vec<usize>>();
     analysis.add_to_ignore(&lines);

--- a/src/test_loader.rs
+++ b/src/test_loader.rs
@@ -275,7 +275,7 @@ fn get_line_addresses(
                 let mut tracemap = TraceMap::new();
                 for (k, val) in &temp_map {
                     for v in val.iter() {
-                        let rpath = config.strip_project_path(&k.path);
+                        let rpath = config.strip_base_dir(&k.path);
                         match v.address {
                             Some(ref a) => trace!(
                                 "Adding trace at address 0x{:x} in {}:{}",
@@ -313,7 +313,7 @@ fn get_line_addresses(
             let line = *line as u64;
             if !result.contains_location(file, line) && !line_analysis.should_ignore(line as usize)
             {
-                let rpath = config.strip_project_path(file);
+                let rpath = config.strip_base_dir(file);
                 trace!(
                     "Adding trace for potentially uncoverable line in {}:{}",
                     rpath.display(),


### PR DESCRIPTION
ignore lines containing "}else{"
add --manifest-path option