### PR TITLE
add --output-dir option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ file.
 ## [Unreleased]
 ### Added
 - Created `CHANGELOG.md`
-- Add --manifest-path option
+- Add `--manifest-path` option
+- Add `--output-dir` option
 
 ### Changed
 - Ignore lines containing "}else{"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -42,6 +42,8 @@ pub struct Config {
     pub branch_coverage: bool,
     /// Output files to generate
     pub generate: Vec<OutputFile>,
+    /// Directory to write output files
+    pub output_directory: PathBuf,
     /// Key relating to coveralls service or repo
     pub coveralls: Option<String>,
     /// Enum representing CI tool used.
@@ -91,6 +93,7 @@ impl Default for Config {
             line_coverage: true,
             branch_coverage: false,
             generate: vec![],
+            output_directory: Default::default(),
             coveralls: None,
             ci_tool: None,
             report_uri: None,
@@ -127,6 +130,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Config {
             line_coverage: get_line_cov(args),
             branch_coverage: get_branch_cov(args),
             generate: get_outputs(args),
+            output_directory: get_output_directory(args),
             coveralls: get_coveralls(args),
             ci_tool: get_ci(args),
             report_uri: get_report_uri(args),
@@ -186,6 +190,10 @@ impl Config {
         .unwrap_or_else(|| path.to_path_buf())
     }
 
+    #[inline]
+    pub fn is_default_output_dir(&self) -> bool {
+        self.output_directory == env::current_dir().unwrap()
+    }
 }
 
 /// Gets the relative path from one directory to another, if it exists.

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -60,6 +60,13 @@ pub(super) fn get_outputs(args: &ArgMatches) -> Vec<OutputFile> {
     values_t!(args.values_of("out"), OutputFile).unwrap_or(vec![])
 }
 
+pub(super) fn get_output_directory(args: &ArgMatches) -> PathBuf {
+    if let Some(path) = args.value_of("output-dir") {
+        return PathBuf::from(path);
+    }
+    env::current_dir().unwrap()
+}
+
 pub(super) fn get_run_types(args: &ArgMatches) -> Vec<RunType> {
     values_t!(args.values_of("run-types"), RunType).unwrap_or(vec![RunType::Tests])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use nix::unistd::*;
 use std::env;
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
+use std::fs::{create_dir_all};
 use walkdir::WalkDir;
 
 pub mod breakpoint;
@@ -325,6 +326,15 @@ pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunErro
         if config.is_coveralls() {
             report::coveralls::export(result, config)?;
             info!("Coverage data sent");
+        }
+
+        if !config.is_default_output_dir() {
+            if create_dir_all(&config.output_directory).is_err() {
+                return Err(RunError::OutFormat(format!(
+                    "Failed to create or locate custom output directory: {:?}",
+                    config.output_directory,
+                )));
+            }
         }
 
         for g in &config.generate {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ fn main() -> Result<(), String> {
                 Arg::from_usage("--out -o [FMT]   'Output format of coverage report'")
                     .possible_values(&OutputFile::variants())
                     .multiple(true),
+                Arg::from_usage("--output-dir [PATH] 'Specify a custom directory to write report files'"),
                 Arg::from_usage("--run-types [TYPE] 'Type of the coverage run'")
                     .possible_values(&RunType::variants())
                     .multiple(true),

--- a/src/report/cobertura.rs
+++ b/src/report/cobertura.rs
@@ -131,8 +131,9 @@ impl Report {
         })
     }
 
-    pub fn export(&self, _config: &Config) -> Result<(), Error> {
-        let mut file = File::create("cobertura.xml")
+    pub fn export(&self, config: &Config) -> Result<(), Error> {
+        let file_path = config.output_directory.join("cobertura.xml");
+        let mut file = File::create(file_path)
             .map_err(|e| Error::ExportError(quick_xml::Error::Io(e)))?;
 
         let mut writer = Writer::new(Cursor::new(vec![]));

--- a/src/report/coveralls.rs
+++ b/src/report/coveralls.rs
@@ -124,7 +124,8 @@ pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError>
         if config.debug {
             if let Ok(text) = serde_json::to_string(&report) {
                 info!("Attempting to write coveralls report to coveralls.json");
-                let _ = fs::write("coveralls.json", text);
+                let file_path = config.output_directory.join("coveralls.json");
+                let _ = fs::write(file_path, text);
             } else {
                 warn!("Failed to serialise coverage report");
             }

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -20,7 +20,7 @@ struct CoverageReport {
     pub files: Vec<SourceFile>,
 }
 
-pub fn export(coverage_data: &TraceMap, _config: &Config) -> Result<(), RunError> {
+pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
     let mut report = CoverageReport { files: Vec::new() };
     for (path, traces) in coverage_data.iter() {
         let content = match read_to_string(path) {
@@ -45,7 +45,8 @@ pub fn export(coverage_data: &TraceMap, _config: &Config) -> Result<(), RunError
         });
     }
 
-    let mut file = match File::create("tarpaulin-report.html") {
+    let file_path = config.output_directory.join("tarpaulin-report.html");
+    let mut file = match File::create(file_path) {
         Ok(k) => k,
         Err(e) => {
             return Err(RunError::Html(format!(


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
Resolves #245 - Adds a new option `--output-dir` that allows the user to specify the target directory to write the reports to. 

I didn't add any automated tests specifically for this, but please let me know if/where I need to add any! 