### PR TITLE
Support JSON output

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -43,6 +43,8 @@ pub enum RunError {
     Html(String),
     #[fail(display = "Failed to generate XML report! Error: {}", _0)]
     XML(cobertura::Error),
+    #[fail(display = "Failed to generate JSON report! Error: {}", _0)]
+    Json(String),
     #[fail(display = "Tarpaulin experienced an internal error")]
     Internal,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,6 +345,9 @@ pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunErro
                 OutputFile::Html => {
                     report::html::export(result, config)?;
                 }
+                OutputFile::Json => {
+                    report::json::export(result, config)?;
+                }
                 _ => {
                     return Err(RunError::OutFormat(
                         "Format currently unsupported".to_string(),

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -21,7 +21,7 @@ struct CoverageReport {
     pub files: Vec<SourceFile>,
 }
 
-pub fn export(coverage_data: &TraceMap, _config: &Config) -> Result<(), RunError> {
+pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
     let mut report = CoverageReport { files: Vec::new() };
     for (path, traces) in coverage_data.iter() {
         let content = match fs::read_to_string(path) {
@@ -46,7 +46,8 @@ pub fn export(coverage_data: &TraceMap, _config: &Config) -> Result<(), RunError
         });
     }
 
-    let mut file = match fs::File::create("tarpaulin-report.json") {
+    let file_path = config.output_directory.join("tarpaulin-report.json");
+    let mut file = match fs::File::create(file_path) {
         Ok(k) => k,
         Err(e) => {
             return Err(RunError::Json(format!(

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,0 +1,71 @@
+use std::{fs, io::Write};
+
+use crate::config::Config;
+use crate::errors::*;
+use crate::traces::{Trace, TraceMap};
+use crate::report::safe_json;
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct SourceFile {
+    pub path: Vec<String>,
+    pub content: String,
+    pub traces: Vec<Trace>,
+    pub covered: usize,
+    pub coverable: usize,
+}
+
+#[derive(Serialize)]
+struct CoverageReport {
+    pub files: Vec<SourceFile>,
+}
+
+pub fn export(coverage_data: &TraceMap, _config: &Config) -> Result<(), RunError> {
+    let mut report = CoverageReport { files: Vec::new() };
+    for (path, traces) in coverage_data.iter() {
+        let content = match fs::read_to_string(path) {
+            Ok(k) => k,
+            Err(e) => {
+                return Err(RunError::Json(format!(
+                    "Unable to read source file to string: {}",
+                    e.to_string()
+                )))
+            }
+        };
+
+        report.files.push(SourceFile {
+            path: path
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy().to_string())
+                .collect(),
+            content,
+            traces: traces.clone(),
+            covered: coverage_data.covered_in_path(path),
+            coverable: coverage_data.coverable_in_path(path),
+        });
+    }
+
+    let mut file = match fs::File::create("tarpaulin-report.json") {
+        Ok(k) => k,
+        Err(e) => {
+            return Err(RunError::Json(format!(
+                "File is not writeable: {}",
+                e.to_string()
+            )))
+        }
+    };
+
+    let report_json = match safe_json::to_string_safe(&report) {
+        Ok(k) => k,
+        Err(e) => {
+            return Err(RunError::Json(format!(
+                "Report isn't serializable: {}",
+                e.to_string()
+            )))
+        }
+    };
+
+    file.write_all(report_json.as_bytes())
+        .map_err(|e| RunError::Json(e.to_string()))
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -6,6 +6,7 @@ mod safe_json;
 pub mod cobertura;
 pub mod coveralls;
 pub mod html;
+pub mod json;
 /// Trait for report formats to implement.
 /// Currently reports must be serializable using serde
 pub trait Report<Out: Serialize> {


### PR DESCRIPTION
While working on a small coverage viewer for Vim, I added basic support for
JSON output. This was previously marked as "not implemented" and would panic.

I didn't do anything fancy, just re-used the existing JSON serializer for
CoverageReport that's written when generating HTML output.