### PR TITLE
Use HashSet for xml package deduplication

### DIFF
--- a/src/report/cobertura.rs
+++ b/src/report/cobertura.rs
@@ -38,6 +38,7 @@
 ///   </packages>
 /// </coverage>
 /// ```
+use std::collections::HashSet;
 use std::error;
 use std::fmt;
 use std::fs::File;
@@ -308,13 +309,11 @@ struct Package {
 }
 
 fn render_packages(config: &Config, traces: &TraceMap) -> Vec<Package> {
-    let mut dirs: Vec<&Path> = traces
+    let dirs: HashSet<&Path> = traces
         .files()
         .into_iter()
         .filter_map(|x| x.parent())
         .collect();
-
-    dirs.dedup();
 
     dirs.into_iter()
         .map(|x| render_package(config, traces, x))


### PR DESCRIPTION
`Vec::dedup` only removes consecutive elements, but HashSet implicitly dedups regardless of order.

I was running into an issue where codecov was failing to show any files at the root `src/` path. Digging deeper, it turned out that the XML contained multiple `<package name="src" ...>` entries which codecov didn't like. The fix properly generates unique names for the `packages` array.