### PR TITLE
Fix invalid output error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ file.
 ### Added
 
 ### Changed
+- Updated phrasing of error messages on invalid `--out` and `--output-dir` command line options
 
 ### Removed
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -30,7 +30,7 @@ pub enum RunError {
     Trace(String),
     #[fail(display = "Failed to report coverage! Error: {}", _0)]
     CovReport(String),
-    #[fail(display = "Output format {} is currently not supported!", _0)]
+    #[fail(display = "{}", _0)]
     OutFormat(String),
     #[fail(display = "{}", _0)]
     IO(std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunErro
                 }
                 _ => {
                     return Err(RunError::OutFormat(
-                        "Format currently unsupported".to_string(),
+                        "Output format is currently not supported!".to_string(),
                     ));
                 }
             }


### PR DESCRIPTION
Hi, I really like your project!

I recently noticed that supplying `tarpaulin` with either an invalid output directory or an unsupported format, the error messages were a bit weird. For example:

`Output format Format currently unsupported is currently not supported!` or 
`Error: "Output format Failed to create or locate custom output directory: \"/test/dir\" is currently not supported!`

I hope this small fix does the job.