### PR TITLE
allow relative paths for manifest-path

### DIFF
--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -27,7 +27,11 @@ pub(super) fn get_branch_cov(args: &ArgMatches) -> bool {
 
 pub(super) fn get_manifest(args: &ArgMatches) -> PathBuf {
     if let Some(path) = args.value_of("manifest-path") {
-        return PathBuf::from(path);
+        let path = PathBuf::from(path);
+        if path.is_relative() {
+            return env::current_dir().unwrap().join(path).canonicalize().unwrap();
+        }
+        return path;
     }
 
     let mut manifest = env::current_dir().unwrap();


### PR DESCRIPTION
This adds support for relative paths for manifest-path, currently only absolute paths are working.