### PR TITLE
actions: Don't fail-fast the matrix build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ jobs:
           - stable
           - beta
           - nightly
+      fail-fast: false
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
By default, GitHub Actions "fails fast;" if one of the builds fails, the rest in the matrix are cancelled, presumably to conserve build minutes.

Since both (i) GitHub Actions is free and unlimited for OSS projects, and (ii) nightly builds are not necessarily a great indication of whether or not a given changeset is actually broken since nightly does break from time to time, it seems wise to prevent failures in e.g. the nightly build from stopping the entire workflow.

Essentially, this PR allows stable/beta builds to continue if nightly fails, but the same does also apply in the other direction.