### PR TITLE
actions: Check formatting before continuing with the build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
           override: true
+          components: rustfmt
       - name: clean
         run: cargo clean
       - name: build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,8 @@ jobs:
           components: rustfmt
       - name: clean
         run: cargo clean
+      - name: check formatting
+        run: cargo fmt --check
       - name: build
         run: cargo build --verbose
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
       - name: clean
         run: cargo clean
       - name: check formatting
-        run: cargo fmt --check
+        run: cargo fmt -- --check
       - name: build
         run: cargo build --verbose
         env:


### PR DESCRIPTION
This PR changes the Actions configuration to include setup for rustfmt and usage of rustfmt before continuing with the rest of the build. Ideally, poorly-formatted code should trigger the earliest feedback, so `cargo fmt` is run before the rest of the build, on all three versions of Rust.