### PR TITLE
get_manifest: Reformat canonicalization chain

### DIFF
--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -29,7 +29,11 @@ pub(super) fn get_manifest(args: &ArgMatches) -> PathBuf {
     if let Some(path) = args.value_of("manifest-path") {
         let path = PathBuf::from(path);
         if path.is_relative() {
-            return env::current_dir().unwrap().join(path).canonicalize().unwrap();
+            return env::current_dir()
+                .unwrap()
+                .join(path)
+                .canonicalize()
+                .unwrap();
         }
         return path;
     }


### PR DESCRIPTION
This reconciles the changes in #274 and #276 to (hopefully) fix the formatting so that the formatting on `develop` is correct.