### PR TITLE
options: add --frozen and --locked flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ file.
 
 ## [Unreleased]
 ### Added
+- `--locked` and `--frozen` options to mirror `cargo test` options
 
 ### Changed
 - Fixed issue where examples were ran with `RunType::Tests`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -77,6 +77,10 @@ pub struct Config {
     pub release: bool,
     /// Build the tests only don't run coverage
     pub no_run: bool,
+    /// Don't update `Cargo.lock`.
+    pub locked: bool,
+    /// Don't update `Cargo.lock` or any caches.
+    pub frozen: bool,
 }
 
 impl Default for Config {
@@ -111,6 +115,8 @@ impl Default for Config {
             release: false,
             all_features: false,
             no_run: false,
+            locked: false,
+            frozen: false,
         }
     }
 }
@@ -149,6 +155,8 @@ impl<'a> From<&'a ArgMatches<'a>> for Config {
             test_timeout: get_timeout(args),
             release: args.is_present("release"),
             no_run: args.is_present("no-run"),
+            locked: args.is_present("locked"),
+            frozen: args.is_present("frozen"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,16 @@ pub fn launch_tarpaulin(config: &Config) -> Result<(TraceMap, i32), RunError> {
     let flag_quiet = if config.verbose { None } else { Some(true) };
 
     // This shouldn't fail so no checking the error.
-    let _ = cargo_config.configure(0u32, flag_quiet, &None, false, false, false, &None, &[]);
+    let _ = cargo_config.configure(
+        0u32,
+        flag_quiet,
+        &None,
+        config.frozen,
+        config.locked,
+        false,
+        &None,
+        &[],
+    );
 
     let workspace = Workspace::new(config.manifest.as_path(), &cargo_config)
         .map_err(|e| RunError::Manifest(e.to_string()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,9 @@ fn main() -> Result<(), String> {
                  --exclude-files [FILE]... 'Exclude given files from coverage results has * wildcard'
                  --timeout -t [SECONDS] 'Integer for the maximum time in seconds without response from test before timeout (default is 1 minute).'
                  --release   'Build in release mode.'
-                 --no-run 'Compile tests but don't run coverage'")
+                 --no-run 'Compile tests but don't run coverage'
+                 --locked 'Do not update Cargo.lock'
+                 --frozen 'Do not update Cargo.lock or any caches'")
             .args(&[
                 Arg::from_usage("--out -o [FMT]   'Output format of coverage report'")
                     .possible_values(&OutputFile::variants())


### PR DESCRIPTION
See #247

---
In CI, separating the build and test steps (e.g., to ensure the build doesn't have access to privileged Docker containers to use `ptrace`), the test should take `--frozen` to ensure that the build is up-to-date rather than possibly building the crate again.