### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/report/cobertura.rs
+++ b/src/report/cobertura.rs
@@ -69,14 +69,6 @@ pub enum Error {
 
 impl error::Error for Error {
     #[inline]
-    fn description(&self) -> &str {
-        match self {
-            Error::ExportError(_) => "Error exporting xml file",
-            Error::Unknown => "Unknown Error",
-        }
-    }
-
-    #[inline]
     fn cause(&self) -> Option<&dyn error::Error> {
         None
     }


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes the implementation of `description` in `cobertura::Error`

Related PR: https://github.com/rust-lang/rust/pull/66919