### PR TITLE
Remove deprecated Error::cause

### DIFF
--- a/src/report/cobertura.rs
+++ b/src/report/cobertura.rs
@@ -67,12 +67,7 @@ pub enum Error {
     ExportError(quick_xml::Error),
 }
 
-impl error::Error for Error {
-    #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for Error {}
 
 impl fmt::Display for Error {
     #[inline]


### PR DESCRIPTION
`Error::cause` has been documented as deprecated since 1.27.0 
This PR:
- Removes the implementation of `cause` in `cobertura::Error`

Related PR: https://github.com/xd009642/tarpaulin/pull/302
