### PR TITLE
Cache tarpaulin on Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ matrix:
 
 before_cache: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    cargo install cargo-tarpaulin -f
+    cargo install cargo-tarpaulin
   fi
 
 script:


### PR DESCRIPTION
Currently the recommended instructions say to use `cargo install -f`, which always rebuilds tarpaulin even if it's already installed. Removing the -f caches the build if it already exists, which can speed  up builds by 10 minutes or more.