### PR TITLE
Bump required clap version to 2.33.0 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "tests/mod.rs"
 [dependencies]
 cargo = "0.40"
 chrono = "0.4"
-clap = "2.31.2"
+clap = "2.33.0"
 coveralls-api = "0.4.0"
 env_logger = "0.7"
 failure = "0.1.3"


### PR DESCRIPTION
Cargo.toml currently specifies a minimum clap version of 2.31.2. However, this is an old
version from March 2018 that cargo-tarpaulin 0.10.0 does not actually compile against.

This is because of a macro issue for Rust 2018 in Clap 2.31.2, where the arg_enum macro
emits a call to the _clap_count_args macro expecting it to be in scope. Since tarpaulin
does not `use clap::macros::_clap_count_args` this is not true, and compilation fails. You can 
observe this by making a new crate which depends on cargo-tarpaulin 0.10.0, or by
updating `Cargo.toml` to specify `"=2.31.2"` instead of `"2.31.2"`

This was fixed in this Dec 2018 commit to `clap`: https://github.com/clap-rs/clap/commit/cfbcb93f94fe8402054945e946bd51ed10b57326#diff-e1576943a5907b15388ab726037ebdb3 which is
included in 2.33.0

Having the old version in Cargo.toml  breaks using cargo-tarpaulin as a library, as in the
tests for the `runtime_macros` crate, which I was attempting to upgrade to the newest version of
tarpaulin, as in this case the Cargo.toml version is consulted. It has not caused any
issues for using it as a binary as in this case Cargo.lock is consulted which already
lists 2.33.0.

This commit updates the version in Cargo.toml to match the version that tarpaulin
is actually built against and compatible with.
