### PR TITLE
Add address field to SourceLocation struct

### DIFF
--- a/src/test_loader.rs
+++ b/src/test_loader.rs
@@ -44,6 +44,7 @@ pub enum LineType {
 struct SourceLocation {
     pub path: PathBuf,
     pub line: u64,
+    pub address: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -196,7 +197,13 @@ where
                                 .map(|&(_, t, fn_name)| (t, fn_name.to_owned()))
                                 .nth(0)
                                 .unwrap_or((LineType::Unknown, None));
-                            let loc = SourceLocation { path, line };
+
+                            let loc = SourceLocation {
+                                path,
+                                line,
+                                address,
+                            };
+
                             if desc != LineType::TestMain && !temp_map.contains_key(&loc) {
                                 temp_map.insert(
                                     loc,

--- a/tests/data/matches/src/lib.rs
+++ b/tests/data/matches/src/lib.rs
@@ -1,3 +1,14 @@
+pub enum LibType {
+    A(usize),
+    B(usize),
+}
+
+pub fn check_libtype_match(lt: LibType) -> usize {
+    match lt {
+        LibType::A(n) => n,
+        LibType::B(n) => n,
+    }
+}
 
 pub fn check_match(x: usize) -> usize {
     match x {
@@ -16,7 +27,6 @@ pub fn destructuring_match(x: u32, y: u32) {
         (2, 2) => 2,
         _ => 0,
     };
-
 }
 
 #[cfg(test)]
@@ -25,6 +35,9 @@ mod tests {
 
     #[test]
     fn it_works() {
+        check_libtype_match(LibType::A(0));
+        check_libtype_match(LibType::B(1));
+
         check_match(0);
         check_match(2);
         check_match(999999);


### PR DESCRIPTION
:wave: Hello! I took a stab at a fix for an issue I've seen in my own crates, thanks for taking a look :smile: 

Because address is used to determine if a line has been covered, this
commit's changes add address to the key used for maps of `TracerData`.

The `gimli` object used to describe line and path can be associated with multiple addresses
which resulted in scenarios where lines that _were_ covered were missed
in the reports (because a `TracerData` associated with line and path, but
not the expected address, got to the map first).

In this commit, a test was added to the `tests/data/matches` crate to illustrate a
scenario that shows a line that was previously uncovered in reporting,
is now covered.

I was personally motivated by the `match` scenario the test crate changes describe, but I'm curious whether these changes result in any wins for coverage in issues like #136 or #262
