### PR TITLE
Add match expr test and run in test suite

### DIFF
--- a/tests/data/matches/src/lib.rs
+++ b/tests/data/matches/src/lib.rs
@@ -1,3 +1,14 @@
+pub enum LibType {
+    A(usize),
+    B(usize),
+}
+
+pub fn check_libtype_match(lt: LibType) -> usize {
+    match lt {
+        LibType::A(n) => n,
+        LibType::B(n) => n,
+    }
+}
 
 pub fn check_match(x: usize) -> usize {
     match x {
@@ -16,7 +27,6 @@ pub fn destructuring_match(x: u32, y: u32) {
         (2, 2) => 2,
         _ => 0,
     };
-
 }
 
 #[cfg(test)]
@@ -25,6 +35,9 @@ mod tests {
 
     #[test]
     fn it_works() {
+        check_libtype_match(LibType::A(0));
+        check_libtype_match(LibType::B(1));
+
         check_match(0);
         check_match(2);
         check_match(999999);

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -120,6 +120,11 @@ fn method_calls_expr_coverage() {
 }
 
 #[test]
+fn match_expr_coverage() {
+    check_percentage("matches", 1.0f64, true);
+}
+
+#[test]
 #[ignore]
 fn benchmark_coverage() {
     let test = "benchmark_coverage";


### PR DESCRIPTION
This commit adds an extra scenario to the suite of match expression
tests. It was added because the changes in commit b8b427cdde6f996df20d4dfbf95a4b19d24a76da
add support for it, so now seems like a good time to account for it :smile: 

This commit also adds the matches tests to those run from
`tests/mod.rs`. I'm not actually sure why it was omitted from that file
though, so maybe that's the wrong thing to do :grimacing:

Thanks for taking a look :raised_hands: 