### PR TITLE
Add json support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ file.
 
 ### Removed
 
+## [0.11.1] 2020-03-04
+### Added
+- Add support for JSON output, including public functions for querying reports programmatically.
+
+### Changed
+- Pulled `trace` function out of `run` in `main.rs` in order to expose public function for creating
+  `TraceMap` structs.
+
+
 ## [0.11.0] 2020-02-26
 ### Added
 - Change in coverage between last 2 runs in HTML report

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -45,6 +45,8 @@ pub enum RunError {
     XML(cobertura::Error),
     #[fail(display = "Failed to generate Lcov report! Error: {}", _0)]
     Lcov(String),
+    #[fail(display = "Failed to generate JSON report! Error: {}", _0)]
+    Json(String),
     #[fail(display = "Tarpaulin experienced an internal error")]
     Internal,
 }
@@ -64,5 +66,11 @@ impl From<nix::Error> for RunError {
 impl From<cobertura::Error> for RunError {
     fn from(e: cobertura::Error) -> Self {
         RunError::XML(e)
+    }
+}
+
+impl From<serde_json::error::Error> for RunError {
+    fn from(e: serde_json::error::Error) -> Self {
+        RunError::Json(e.to_string())
     }
 }

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -4,6 +4,7 @@ use std::{fs, io::Write};
 use crate::config::Config;
 use crate::errors::*;
 use crate::traces::{Trace, TraceMap};
+use std::slice::Iter;
 
 use serde::Serialize;
 
@@ -17,8 +18,22 @@ struct SourceFile {
 }
 
 #[derive(Serialize)]
-struct CoverageReport {
-    pub files: Vec<SourceFile>,
+pub struct CoverageReport {
+    files: Vec<SourceFile>,
+}
+
+impl CoverageReport {
+    fn iter(&self) -> Iter<SourceFile> {
+        self.files.iter()
+    }
+
+    pub fn covered(&self) -> Vec<usize> {
+        self.iter().map(|r| r.covered).collect()
+    }
+
+    pub fn coverable(&self) -> Vec<usize> {
+        self.iter().map(|r| r.coverable).collect()
+    }
 }
 
 impl From<&TraceMap> for Vec<SourceFile> {

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -9,11 +9,11 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 struct SourceFile {
-    pub path: Vec<String>,
-    pub content: String,
-    pub traces: Vec<Trace>,
-    pub covered: usize,
-    pub coverable: usize,
+    path: Vec<String>,
+    content: String,
+    traces: Vec<Trace>,
+    covered: usize,
+    coverable: usize,
 }
 
 #[derive(Serialize)]

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,0 +1,68 @@
+use std::convert::From;
+use std::{fs, io::Write};
+
+use crate::config::Config;
+use crate::errors::*;
+use crate::traces::{Trace, TraceMap};
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct SourceFile {
+    pub path: Vec<String>,
+    pub content: String,
+    pub traces: Vec<Trace>,
+    pub covered: usize,
+    pub coverable: usize,
+}
+
+#[derive(Serialize)]
+struct CoverageReport {
+    pub files: Vec<SourceFile>,
+}
+
+impl From<&TraceMap> for Vec<SourceFile> {
+    fn from(coverage_data: &TraceMap) -> Self {
+        coverage_data
+            .iter()
+            .map(|(path, traces)| -> Result<SourceFile, RunError> {
+                let content = fs::read_to_string(path).map_err(RunError::from)?;
+                Ok(SourceFile {
+                    path: path
+                        .components()
+                        .map(|c| c.as_os_str().to_string_lossy().to_string())
+                        .collect(),
+                    content: content,
+                    traces: traces.clone(),
+                    covered: coverage_data.covered_in_path(path),
+                    coverable: coverage_data.coverable_in_path(path),
+                })
+            })
+            .filter_map(Result::ok)
+            .collect()
+    }
+}
+
+impl From<&TraceMap> for CoverageReport {
+    fn from(coverage_data: &TraceMap) -> Self {
+        CoverageReport {
+            files: Vec::<SourceFile>::from(coverage_data),
+        }
+    }
+}
+
+type JsonStringResult = Result<String, serde_json::error::Error>;
+
+impl Into<JsonStringResult> for &TraceMap {
+    fn into(self) -> JsonStringResult {
+        serde_json::to_string(&CoverageReport::from(self))
+    }
+}
+
+pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
+    let file_path = config.output_directory.join("tarpaulin-report.json");
+    let report: JsonStringResult = coverage_data.into();
+    fs::File::create(file_path)?
+        .write_all(report?.as_bytes())
+        .map_err(RunError::from)
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -10,6 +10,7 @@ use std::io::BufReader;
 pub mod cobertura;
 pub mod coveralls;
 pub mod html;
+pub mod json;
 pub mod lcov;
 mod safe_json;
 /// Trait for report formats to implement.
@@ -73,6 +74,9 @@ fn generate_requested_reports(config: &Config, result: &TraceMap) -> Result<(), 
             }
             OutputFile::Lcov => {
                 lcov::export(result, config)?;
+            }
+            OutputFile::Json => {
+                json::export(result, config)?;
             }
             _ => {
                 return Err(RunError::OutFormat(


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
This PR is based on pull request https://github.com/xd009642/tarpaulin/pull/250. This should provide the same functionality as that pull request, except that I refactored that code in order to expose methods that allowed programmatic access of JSON report contents. The goal is to be able to invoke these methods from an external library in order to access the `CoverageReport` struct.