### PR TITLE
Reduce the size of docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM rust
+FROM rust:slim as builder
 
 RUN apt-get update && \
-    apt-get install -y cmake && \
+    apt-get install -y libssl-dev pkg-config cmake zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/tarpaulin
@@ -13,12 +13,16 @@ COPY Cargo.lock .
 RUN mkdir .cargo
 RUN cargo vendor > .cargo/config
 
-COPY . /opt/tarpaulin/
+COPY src /opt/tarpaulin/src
 
 RUN cd /opt/tarpaulin/ && \
     cargo install --locked --path . && \
     rm -rf /opt/tarpaulin/ && \
     rm -rf /usr/local/cargo/registry/
+
+FROM rust:slim
+
+COPY --from=builder /usr/local/cargo/bin/cargo-tarpaulin /usr/local/cargo/bin/cargo-tarpaulin
 
 WORKDIR /volume
 

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -1,4 +1,4 @@
-FROM rustlang/rust:nightly
+FROM rustlang/rust:nightly-slim as builder
 
 RUN apt-get update && \
     apt-get install -y cmake && \
@@ -13,12 +13,16 @@ COPY Cargo.lock .
 RUN mkdir .cargo
 RUN cargo vendor > .cargo/config
 
-COPY . /opt/tarpaulin/
+COPY src /opt/tarpaulin/src
 
 RUN cd /opt/tarpaulin/ && \
     cargo install --locked --path . && \
     rm -rf /opt/tarpaulin/ && \
     rm -rf /usr/local/cargo/registry/
+
+FROM rustlang/rust:nightly-slim
+
+COPY --from=builder /usr/local/cargo/bin/cargo-tarpaulin /usr/local/cargo/bin/cargo-tarpaulin
 
 WORKDIR /volume
 


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
Using builder pattern reduced the size from 1.7 GB to 1.2 GB
Using rust-slim reduced the size from 1.2 GB to 0.5 GB