### PR TITLE
html: support coverage diffs with deleted sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ file.
 ### Changed
 - Reverted Dockerfiles to full images added dockerfiles with `-slim` postfix for slim images
 - `todo!()` macros are now ignored with the `--ignore-panics` flag
+- The HTML output report will no longer fail if a previous run contains a source file that no longer exists
 
 ### Removed
 


### PR DESCRIPTION
When a previous result mentions a non-existent file, just ignore the
error; it has probably just been deleted since the last run (different
branch, reworked source tree, etc.).

Fixes #382