### PR TITLE
Added full toolchain name to create_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ file.
 
 ### Changed
 - Find target folder from metadata if not provided and place reports there (fixes running from packages inside workspaces)
+- Using date-locked toolchains no longer defaults to trying to use a toolchain with the channel name and no date
 
 ### Removed
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -145,11 +145,7 @@ fn create_command(manifest_path: &str, config: &Config, ty: &RunType) -> Command
         test_cmd.args(&["+nightly", "test"]);
     } else {
         if let Ok(toolchain) = env::var("RUSTUP_TOOLCHAIN") {
-            if toolchain.starts_with("nightly") {
-                test_cmd.arg("+nightly");
-            } else if toolchain.starts_with("beta") {
-                test_cmd.arg("+beta");
-            }
+            test_cmd.arg(format!("+{}", toolchain));
         }
         if *ty != RunType::Examples {
             test_cmd.args(&["test", "--no-run"]);

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -142,7 +142,14 @@ pub fn get_tests(config: &Config) -> Result<Vec<TestBinary>, RunError> {
 fn create_command(manifest_path: &str, config: &Config, ty: &RunType) -> Command {
     let mut test_cmd = Command::new("cargo");
     if *ty == RunType::Doctests {
-        test_cmd.args(&["+nightly", "test"]);
+        if let Some(toolchain) = env::var("RUSTUP_TOOLCHAIN")
+            .ok()
+            .filter(|t| t.starts_with("nightly"))
+        {
+            test_cmd.args(&[format!("+{}", toolchain).as_str(), "test"]);
+        } else {
+            test_cmd.args(&["+nightly", "test"]);
+        }
     } else {
         if let Ok(toolchain) = env::var("RUSTUP_TOOLCHAIN") {
             test_cmd.arg(format!("+{}", toolchain));


### PR DESCRIPTION
This closes #404 

This fixes a problem where toolchains that are locked by date will be overridden by Tarpaulin.

I'm not entirely sure if there are any edge cases this won't handle in terms of toolchains, but the notation `cargo +<toolchain> command` should allow the full toolchain name just fine.

Please let me know if anything needs to be changed :smiley: