### PR TITLE
Allow more CLI options to override config file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ file.
 ### Changed
 - Find target folder from metadata if not provided and place reports there (fixes running from packages inside workspaces)
 - Using date-locked toolchains no longer defaults to trying to use a toolchain with the channel name and no date
+- The following CLI options now take effect even when a custom config file is
+  in place: `output-dir`, `target-dir`, `root`, `coveralls`, `ciserver`,
+  `report-uri`.
 
 ### Removed
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -59,7 +59,7 @@ pub struct Config {
     pub branch_coverage: bool,
     /// Directory to write output files
     #[serde(rename = "output-dir")]
-    pub output_directory: PathBuf,
+    pub output_directory: Option<PathBuf>,
     /// Key relating to coveralls service or repo
     pub coveralls: Option<String>,
     /// Enum representing CI tool used.
@@ -291,6 +291,14 @@ impl Config {
         }
     }
 
+    pub fn output_dir(&self) -> PathBuf {
+        if let Some(ref path) = self.output_directory {
+            path.clone()
+        } else {
+            env::current_dir().unwrap()
+        }
+    }
+
     pub fn get_config_vec(file_configs: std::io::Result<Vec<Self>>, backup: Self) -> ConfigWrapper {
         if file_configs.is_err() {
             warn!("Failed to deserialize config file falling back to provided args");
@@ -381,6 +389,8 @@ impl Config {
         self.ci_tool = Config::pick_optional_config(&self.ci_tool, &other.ci_tool);
         self.report_uri = Config::pick_optional_config(&self.report_uri, &other.report_uri);
         self.target_dir = Config::pick_optional_config(&self.target_dir, &other.target_dir);
+        self.output_directory =
+            Config::pick_optional_config(&self.output_directory, &other.output_directory);
 
         if !other.excluded_files_raw.is_empty() {
             self.excluded_files_raw
@@ -451,7 +461,7 @@ impl Config {
 
     #[inline]
     pub fn is_default_output_dir(&self) -> bool {
-        self.output_directory == env::current_dir().unwrap()
+        self.output_directory.is_none()
     }
 }
 
@@ -645,6 +655,48 @@ mod tests {
             a_config.report_uri,
             Some("https://example.com/report".to_string())
         );
+    }
+
+    #[test]
+    fn output_dir_merge() {
+        let toml = r#"[has_dir]
+        output-dir = "foo"
+
+        [no_dir]
+        coveralls = "xyz"
+        
+        [other_dir]
+        output-dir = "bar"
+        "#;
+
+        let configs = Config::parse_config_toml(toml.as_bytes()).unwrap();
+        let has_dir = configs
+            .iter()
+            .find(|x| x.name == "has_dir")
+            .unwrap()
+            .clone();
+        let no_dir = configs.iter().find(|x| x.name == "no_dir").unwrap().clone();
+        let other_dir = configs
+            .iter()
+            .find(|x| x.name == "other_dir")
+            .unwrap()
+            .clone();
+
+        let mut merged_into_has_dir = has_dir.clone();
+        merged_into_has_dir.merge(&no_dir);
+        assert_eq!(merged_into_has_dir.output_dir(), PathBuf::from("foo"));
+
+        let mut merged_into_no_dir = no_dir.clone();
+        merged_into_no_dir.merge(&has_dir);
+        assert_eq!(merged_into_no_dir.output_dir(), PathBuf::from("foo"));
+
+        let mut neither_merged_dir = no_dir.clone();
+        neither_merged_dir.merge(&no_dir);
+        assert_eq!(neither_merged_dir.output_dir(), env::current_dir().unwrap());
+
+        let mut both_merged_dir = has_dir.clone();
+        both_merged_dir.merge(&other_dir);
+        assert_eq!(both_merged_dir.output_dir(), PathBuf::from("bar"));
     }
 
     #[test]

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -99,11 +99,8 @@ pub(super) fn get_outputs(args: &ArgMatches) -> Vec<OutputFile> {
     values_t!(args.values_of("out"), OutputFile).unwrap_or(vec![])
 }
 
-pub(super) fn get_output_directory(args: &ArgMatches) -> PathBuf {
-    if let Some(path) = args.value_of("output-dir") {
-        return PathBuf::from(path);
-    }
-    env::current_dir().unwrap()
+pub(super) fn get_output_directory(args: &ArgMatches) -> Option<PathBuf> {
+    args.value_of("output-dir").map(|path| PathBuf::from(path))
 }
 
 pub(super) fn get_run_types(args: &ArgMatches) -> Vec<RunType> {

--- a/src/report/cobertura.rs
+++ b/src/report/cobertura.rs
@@ -120,7 +120,7 @@ impl Report {
     }
 
     pub fn export(&self, config: &Config) -> Result<(), Error> {
-        let file_path = config.output_directory.join("cobertura.xml");
+        let file_path = config.output_dir().join("cobertura.xml");
         let mut file =
             File::create(file_path).map_err(|e| Error::ExportError(quick_xml::Error::Io(e)))?;
 

--- a/src/report/coveralls.rs
+++ b/src/report/coveralls.rs
@@ -124,7 +124,7 @@ pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError>
         if config.debug {
             if let Ok(text) = serde_json::to_string(&report) {
                 info!("Attempting to write coveralls report to coveralls.json");
-                let file_path = config.output_directory.join("coveralls.json");
+                let file_path = config.output_dir().join("coveralls.json");
                 let _ = fs::write(file_path, text);
             } else {
                 warn!("Failed to serialise coverage report");

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -62,7 +62,7 @@ fn get_json(coverage_data: &TraceMap, context: Context) -> Result<String, RunErr
 }
 
 pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
-    let file_path = config.output_directory.join("tarpaulin-report.html");
+    let file_path = config.output_dir().join("tarpaulin-report.html");
     let mut file = match File::create(file_path) {
         Ok(k) => k,
         Err(e) => {

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -75,7 +75,7 @@ impl Into<JsonStringResult> for &TraceMap {
 }
 
 pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
-    let file_path = config.output_directory.join("tarpaulin-report.json");
+    let file_path = config.output_dir().join("tarpaulin-report.json");
     let report: JsonStringResult = coverage_data.into();
     fs::File::create(file_path)?
         .write_all(report?.as_bytes())

--- a/src/report/lcov.rs
+++ b/src/report/lcov.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::Write;
 
 pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
-    let file_path = config.output_directory.join("lcov.info");
+    let file_path = config.output_dir().join("lcov.info");
     let mut file = match File::create(file_path) {
         Ok(k) => k,
         Err(e) => {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -57,7 +57,7 @@ fn generate_requested_reports(config: &Config, result: &TraceMap) -> Result<(), 
     }
 
     if !config.is_default_output_dir() {
-        if create_dir_all(&config.output_directory).is_err() {
+        if create_dir_all(&config.output_dir()).is_err() {
             return Err(RunError::OutFormat(format!(
                 "Failed to create or locate custom output directory: {:?}",
                 config.output_directory,


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

This PR allows more config items to be specified on the command line and override an existing config file on an adhoc basis to allow for per run or per environment overrides.

In particular, it adds support for overriding the following options:

* Target directory for Rust builds, for example if a CI build needs to output to a specific cached location.
* Output directory for Tarpaulin output, for the same reason
* Coveralls related config items (coveralls, ci_tool and report_uri). Primarily the coveralls flag was desired, to allow use in environments other than Travis which require access to a secret API key that you may not wish to include in repo, but I included all three options for consistency.
* Crate root, to allow for a run to target only a single crate in a workspace.

Previous discussion: #414 
