### PR TITLE
config: support CARGO_TARPAULIN_TARGET_DIR as a source for the target dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ file.
 ## [Unreleased]
 ### Added
 
+- The `CARGO_TARPAULIN_TARGET_DIR` environment variable may be used to set the
+  default target directory for tarpaulin artifacts. The command line argument
+  has precedence.
+
 ### Changed
 - Find target folder from metadata if not provided and place reports there (fixes running from packages inside workspaces)
 - Using date-locked toolchains no longer defaults to trying to use a toolchain with the channel name and no date

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -59,24 +59,27 @@ pub(super) fn default_manifest() -> PathBuf {
 }
 
 pub(super) fn get_target_dir(args: &ArgMatches) -> Option<PathBuf> {
-    if let Some(path) = args.value_of("target-dir") {
-        let path = PathBuf::from(path);
-        if !path.exists() {
-            let _ = create_dir_all(&path);
-        }
-        let path = if path.is_relative() {
-            env::current_dir()
-                .unwrap()
-                .join(path)
-                .canonicalize()
-                .unwrap()
-        } else {
-            path
-        };
-        Some(path)
+    let path = if let Some(path) = args.value_of("target-dir") {
+        PathBuf::from(path)
+    } else if let Some(envvar) = env::var_os("CARGO_TARPAULIN_TARGET_DIR") {
+        PathBuf::from(envvar)
     } else {
-        None
+        return None;
+    };
+
+    if !path.exists() {
+        let _ = create_dir_all(&path);
     }
+    let path = if path.is_relative() {
+        env::current_dir()
+            .unwrap()
+            .join(path)
+            .canonicalize()
+            .unwrap()
+    } else {
+        path
+    };
+    Some(path)
 }
 
 pub(super) fn get_root(args: &ArgMatches) -> Option<String> {


### PR DESCRIPTION

Fixes: #383 

---
This allows users to change the default target directory for their own environment without having to add `tarpaulin.toml` files to every repository changing it for every developer.