### PR TITLE
README: Add nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Tarpaulin used to rely on Cargo as a dependency and then require an ssl install
 as well as other libraries but now it uses your system cargo simplifying the
 installation and massively reducing the install time on CI.
 
+When using the [Nix](https://nixos.org/nix) package manager, the `nixpkgs.cargo-tarpaulin` package can be used.
+This ensures that tarpaulin will be built with the same rust version as the rest of your packages.
+
 ### Command line
 
 To get detailed help on available arguments when running tarpaulin call:


### PR DESCRIPTION
**WIP**: Waiting for the upstream package to be merged: [nixos/nixpkgs#87571](https://github.com/NixOS/nixpkgs/pull/87571).

Add [Nix](https://nixos.org/nix/) installation instructions to the README. This may be considered an unnecessary addition, if so, I am fine with the PR being closed permanently.
The addition is aimed to direct Nix users to the necessary package for installing cargo-tarpaulin. For Nix users, using the nix package installation method instead of the `cargo install` method is advisable as it ensures tarpaulin is built using the rust version specified by the user.