### PR TITLE
Bugfix/lookup report from config target dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ file.
 
 ### Changed
 - Examples coverage now runs the tests that would be ran with `cargo test --examples`
+- Look up previous report from correct target directory.
 
 ### Removed
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -113,22 +113,18 @@ fn print_missing_lines(config: &Config, result: &TraceMap) {
 
 fn get_previous_result(config: &Config) -> Option<TraceMap> {
     // Check for previous report
-    if let Some(project_dir) = config.manifest.parent() {
-        let mut report_dir = project_dir.join("target");
-        report_dir.push("tarpaulin");
-        if report_dir.exists() {
-            // is report there?
-            report_dir.push("coverage.json");
-            let file = File::open(&report_dir).ok()?;
-            let reader = BufReader::new(file);
-            serde_json::from_reader(reader).ok()
-        } else {
-            // make directory
-            create_dir_all(&report_dir)
-                .unwrap_or_else(|e| error!("Failed to create report directory: {}", e));
-            None
-        }
+    let mut report_dir = config.target_dir();
+    report_dir.push("tarpaulin");
+    if report_dir.exists() {
+        // is report there?
+        report_dir.push("coverage.json");
+        let file = File::open(&report_dir).ok()?;
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader).ok()
     } else {
+        // make directory
+        create_dir_all(&report_dir)
+            .unwrap_or_else(|e| error!("Failed to create report directory: {}", e));
         None
     }
 }


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

Heya, when:

* running `cargo tarpaulin` in `<repo>/member_crate`
* setting `target-dir` to the workspace root: `--target-dir ..`

`cargo tarpaulin` still looks for the previous coverage report to compare with in `<repo>/member_crate/target/tarpaulin`.

This PR fixes that by calculating the report directory from the `target-dir`.