### PR TITLE
Feature/take in compilation target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ file.
 
 ## [Unreleased]
 ### Added
+- Compilation target is now accepted through the `--target` parameter.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ OPTIONS:
     -r, --root <DIR>                 Calculates relative paths to root directory. If --manifest-path isn't specified it
                                      will look for a Cargo.toml in root
         --run-types <TYPE>...        Type of the coverage run [possible values: Tests, Doctests, Benchmarks, Examples]
+        --target [TRIPLE]            Compilation target triple
         --target-dir <DIR>           Directory for all generated artifacts
     -t, --timeout <SECONDS>          Integer for the maximum time in seconds without response from test before timeout
                                      (default is 1 minute).

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -199,6 +199,9 @@ fn init_args(test_cmd: &mut Command, config: &Config) {
     if config.release {
         test_cmd.arg("--release");
     }
+    if let Some(target) = config.target.as_ref() {
+        test_cmd.args(&["--target", target]);
+    }
     let args = vec![
         "--target-dir".to_string(),
         format!("{}", config.target_dir().display()),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -392,6 +392,7 @@ impl Config {
         self.coveralls = Config::pick_optional_config(&self.coveralls, &other.coveralls);
         self.ci_tool = Config::pick_optional_config(&self.ci_tool, &other.ci_tool);
         self.report_uri = Config::pick_optional_config(&self.report_uri, &other.report_uri);
+        self.target = Config::pick_optional_config(&self.target, &other.target);
         self.target_dir = Config::pick_optional_config(&self.target_dir, &other.target_dir);
         self.output_directory =
             Config::pick_optional_config(&self.output_directory, &other.output_directory);
@@ -633,6 +634,27 @@ mod tests {
 
         assert_eq!(config.excluded_files_raw.len(), 2);
         assert_eq!(configs[0].excluded_files_raw.len(), 1);
+    }
+
+    #[test]
+    fn target_merge() {
+        let toml_a = r#""#;
+        let toml_b = r#"target = "wasm32-unknown-unknown""#;
+        let toml_c = r#"target = "x86_64-linux-gnu""#;
+
+        let mut a: Config = toml::from_slice(toml_a.as_bytes()).unwrap();
+        let mut b: Config = toml::from_slice(toml_b.as_bytes()).unwrap();
+        let c: Config = toml::from_slice(toml_c.as_bytes()).unwrap();
+
+        assert_eq!(a.target, None);
+        assert_eq!(b.target, Some(String::from("wasm32-unknown-unknown")));
+        assert_eq!(c.target, Some(String::from("x86_64-linux-gnu")));
+
+        b.merge(&c);
+        assert_eq!(b.target, Some(String::from("x86_64-linux-gnu")));
+
+        a.merge(&b);
+        assert_eq!(a.target, Some(String::from("x86_64-linux-gnu")));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -95,6 +95,8 @@ pub struct Config {
     pub locked: bool,
     /// Don't update `Cargo.lock` or any caches.
     pub frozen: bool,
+    /// Build for the target triple.
+    pub target: Option<String>,
     /// Directory for generated artifacts
     #[serde(rename = "target-dir")]
     target_dir: Option<PathBuf>,
@@ -166,6 +168,7 @@ impl Default for Config {
             no_run: false,
             locked: false,
             frozen: false,
+            target: None,
             target_dir: None,
             offline: false,
             metadata: RefCell::new(None),
@@ -217,6 +220,7 @@ impl<'a> From<&'a ArgMatches<'a>> for ConfigWrapper {
             no_run: args.is_present("no-run"),
             locked: args.is_present("locked"),
             frozen: args.is_present("frozen"),
+            target: get_target(args),
             target_dir: get_target_dir(args),
             offline: args.is_present("offline"),
             metadata: RefCell::new(None),
@@ -724,6 +728,7 @@ mod tests {
         no-run = true
         locked = true
         frozen = true
+        target = "wasm32-unknown-unknown"
         target-dir = "/tmp"
         offline = true
         Z = ["something-nightly"]
@@ -754,6 +759,8 @@ mod tests {
         assert!(config.no_run);
         assert!(config.locked);
         assert!(config.frozen);
+        assert_eq!(Some(String::from("wasm32-unknown-unknown")), config.target);
+        assert_eq!(Some(Path::new("/tmp").to_path_buf()), config.target_dir);
         assert!(config.offline);
         assert_eq!(config.test_timeout, Duration::from_secs(5));
         assert_eq!(config.unstable_features.len(), 1);

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -59,9 +59,7 @@ pub(super) fn default_manifest() -> PathBuf {
 }
 
 pub(super) fn get_target(args: &ArgMatches) -> Option<String> {
-    args.value_of("target").map(String::from).or_else(|| {
-        env::var_os("CARGO_BUILD_TARGET").and_then(|env_var| env_var.into_string().ok())
-    })
+    args.value_of("target").map(String::from)
 }
 
 pub(super) fn get_target_dir(args: &ArgMatches) -> Option<PathBuf> {

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -58,6 +58,12 @@ pub(super) fn default_manifest() -> PathBuf {
     manifest.canonicalize().unwrap_or(manifest)
 }
 
+pub(super) fn get_target(args: &ArgMatches) -> Option<String> {
+    args.value_of("target").map(String::from).or_else(|| {
+        env::var_os("CARGO_BUILD_TARGET").and_then(|env_var| env_var.into_string().ok())
+    })
+}
+
 pub(super) fn get_target_dir(args: &ArgMatches) -> Option<PathBuf> {
     let path = if let Some(path) = args.value_of("target-dir") {
         PathBuf::from(path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ fn main() -> Result<(), String> {
                  --no-run 'Compile tests but don't run coverage'
                  --locked 'Do not update Cargo.lock'
                  --frozen 'Do not update Cargo.lock or any caches'
+                 --target [TRIPLE] 'Compilation target triple'
                  --target-dir [DIR] 'Directory for all generated artifacts'
                  --offline 'Run without accessing the network'
                  -Z [FEATURES]...   'List of unstable nightly only flags'")


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

Heya, some projects compile to different compilation targets, and so need a way to wire that through to `cargo`. This PR adds that functionality, so users can now go:

```bash
cargo tarpaulin --target x86_64-linux-gnu
```

or in `tarpaulin.toml`:

```toml
[linux_32]
target = "x86-linux-gnu"

[linux_64]
target = "x86_64-linux-gnu"
```
