### PR TITLE
Bugfix/workspace and features configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ file.
 - Added doc comments to ignorable lines in source analysis
 - Feature configurations in `tarpaulin.toml` are now run in order of declaration.
 - Compilation failure results in `cargo tarpaulin` execution failure.
+- `workspace` flag is correctly propagated to feature configurations.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ file.
 - Compilation failure results in `cargo tarpaulin` execution failure.
 - `workspace` flag is correctly propagated to feature configurations.
 - `features` now takes in a string e.g. `"f1 f2"`, instead of an array of strings `["f1", "f2"]`.
+- `packages` in feature configurations are now read.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ file.
 - Feature configurations in `tarpaulin.toml` are now run in order of declaration.
 - Compilation failure results in `cargo tarpaulin` execution failure.
 - `workspace` flag is correctly propagated to feature configurations.
+- `features` now takes in a string e.g. `"f1 f2"`, instead of an array of strings `["f1", "f2"]`.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -391,10 +391,10 @@ the projects manifest or in the root directory that will be used unless
 
 ```toml
 [feature_a_coverage]
-features = ["feature_a"]
+features = "feature_a"
 
-[feature_b_coverage]
-features = ["feature_b"]
+[feature_a_and_b_coverage]
+features = "feature_a feature_b"
 release = true
 
 [report]
@@ -404,10 +404,10 @@ out = ["Html", "Xml"]
 
 Here we'd create three configurations, one would run your tests with
 `feature_a` enabled, and the other with the tests built in release and
-`feature_b` enabled. The last configuration uses a reserved configuration name
-`report` and this doesn't result in a coverage run but affects the report
-output. This is a reserved feature name and any non-reporting based options
-chosen will have no effect on the output of tarpaulin.
+both `feature_a` and `feature_b` enabled. The last configuration uses a reserved
+configuration name `report` and this doesn't result in a coverage run but
+affects the report output. This is a reserved feature name and any non-reporting
+based options chosen will have no effect on the output of tarpaulin.
 
 For reference on available keys and their types refer to the CLI help text
 at the start of the readme or `src/config/mod.rs` for the concrete types

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -177,10 +177,9 @@ fn init_args(test_cmd: &mut Command, config: &Config) {
     if config.frozen {
         test_cmd.arg("--frozen");
     }
-    if !config.features.is_empty() {
-        let mut args = vec!["--features".to_string()];
-        args.extend_from_slice(&config.features);
-        test_cmd.args(args);
+    if let Some(features) = config.features.as_ref() {
+        test_cmd.arg("--features");
+        test_cmd.arg(features);
     }
     if config.all_features {
         test_cmd.arg("--all-features");

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -193,6 +193,10 @@ fn init_args(test_cmd: &mut Command, config: &Config) {
     if config.release {
         test_cmd.arg("--release");
     }
+    config.packages.iter().for_each(|package| {
+        test_cmd.arg("--package");
+        test_cmd.arg(package);
+    });
     if let Some(target) = config.target.as_ref() {
         test_cmd.args(&["--target", target]);
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -118,8 +118,8 @@ pub struct Config {
     /// Varargs to be forwarded to the test executables.
     #[serde(rename = "args")]
     pub varargs: Vec<String>,
-    /// Features to include in the target project build
-    pub features: Vec<String>,
+    /// Features to include in the target project build, e.g. "feature1 feature2"
+    pub features: Option<String>,
     /// Unstable cargo features to use
     #[serde(rename = "Z")]
     pub unstable_features: Vec<String>,
@@ -154,7 +154,7 @@ impl Default for Config {
             report_uri: None,
             forward_signals: false,
             no_default_features: false,
-            features: vec![],
+            features: None,
             unstable_features: vec![],
             all: false,
             packages: vec![],
@@ -207,7 +207,7 @@ impl<'a> From<&'a ArgMatches<'a>> for ConfigWrapper {
             forward_signals: args.is_present("forward"),
             all_features: args.is_present("all-features"),
             no_default_features: args.is_present("no-default-features"),
-            features: get_list(args, "features"),
+            features: get_string(args, "features"),
             unstable_features: get_list(args, "Z"),
             all: args.is_present("all") | args.is_present("workspace"),
             packages: get_list(args, "packages"),
@@ -750,7 +750,7 @@ mod tests {
         coveralls = "hello"
         report-uri = "http://hello.com"
         no-default-features = true
-        features = ["a"]
+        features = "a b"
         all-features = true
         workspace = true
         packages = ["pack_1"]
@@ -800,8 +800,7 @@ mod tests {
         assert_eq!(config.unstable_features[0], "something-nightly");
         assert_eq!(config.varargs.len(), 1);
         assert_eq!(config.varargs[0], "--nocapture");
-        assert_eq!(config.features.len(), 1);
-        assert_eq!(config.features[0], "a");
+        assert_eq!(config.features, Some(String::from("a b")));
         assert_eq!(config.excluded_files_raw.len(), 1);
         assert_eq!(config.excluded_files_raw[0], "fuzz/*");
         assert_eq!(config.packages.len(), 1);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -391,6 +391,7 @@ impl Config {
         self.target_dir = Config::pick_optional_config(&self.target_dir, &other.target_dir);
         self.output_directory =
             Config::pick_optional_config(&self.output_directory, &other.output_directory);
+        self.all |= other.all;
 
         if !other.excluded_files_raw.is_empty() {
             self.excluded_files_raw
@@ -650,6 +651,21 @@ mod tests {
 
         a.merge(&b);
         assert_eq!(a.target, Some(String::from("x86_64-linux-gnu")));
+    }
+
+    #[test]
+    fn workspace_merge() {
+        let toml_a = r#"workspace = false"#;
+        let toml_b = r#"workspace = true"#;
+
+        let mut a: Config = toml::from_slice(toml_a.as_bytes()).unwrap();
+        let b: Config = toml::from_slice(toml_b.as_bytes()).unwrap();
+
+        assert_eq!(a.all, false);
+        assert_eq!(b.all, true);
+
+        a.merge(&b);
+        assert_eq!(a.all, true);
     }
 
     #[test]

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -4,12 +4,17 @@ use coveralls_api::CiService;
 use log::error;
 use regex::Regex;
 use serde::de::{self, Deserializer};
+use std::borrow::Cow;
 use std::env;
 use std::fmt;
 use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
+
+pub(super) fn get_string(args: &ArgMatches, key: &str) -> Option<String> {
+    args.value_of_lossy(key).map(Cow::into_owned).or(None)
+}
 
 pub(super) fn get_list(args: &ArgMatches, key: &str) -> Vec<String> {
     args.values_of_lossy(key).unwrap_or_else(Vec::new)

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), String> {
                  --coveralls [KEY]  'Coveralls key, either the repo token, or if you're using travis use $TRAVIS_JOB_ID and specify travis-{ci|pro} in --ciserver'
                  --report-uri [URI] 'URI to send report to, only used if the option --coveralls is used'
                  --no-default-features 'Do not include default features'
-                 --features [FEATURE]... 'Features to be included in the target project'
+                 --features \"f1 f2\" 'Features to be included in the target project'
                  --all-features 'Build all available features'
                  --all        'Alias for --workspace (deprecated)'
                  --workspace 'Test all packages in the workspace'

--- a/tests/data/configs/tarpaulin.toml
+++ b/tests/data/configs/tarpaulin.toml
@@ -1,5 +1,5 @@
 [coverage]
-features = ["feature1"]
+features = "feature1"
 
 [coverage_2]
-features = ["feature2"]
+features = "feature2"


### PR DESCRIPTION
note: this is based over https://github.com/xd009642/tarpaulin/pull/449 to avoid a merge conflict. I could base it over `develop` if you prefer.

Changes to `config`:

* `all` (workspace) configuration is merged when merging configurations. This means when running `cargo tarpaulin --workspace` when `tarpaulin.toml` contains multiple feature configurations, it would propagate the `all` flag to all of the configurations.
* `features` takes in an `Option<String>` instead of `Vec<String>`.

    Previously `tarpaulin` was running cargo with features like this:

    ```bash
    # this would only run cargo with feature "a", "b" would be ignored
    cargo test --features "a" "b"
    ```

    Cargo expects it to actually be:

    ```bash
    cargo test --features "a b"
    ```

    ---

    I could instead of switching `Vec` to `Option`, just join with `" "` when constructing the command, but this way the command line interface is consistent with `cargo`.
