### PR TITLE
docs(readme): add [ ] to the config file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,14 +392,14 @@ the projects manifest or in the root directory that will be used unless
 
 ```toml
 [feature_a_coverage]
-features = "feature_a"
+features = ["feature_a"]
 
 [feature_a_and_b_coverage]
-features = "feature_a feature_b"
+features = ["feature_a feature_b"]
 release = true
 
 [report]
-coveralls = "coveralls_key"
+coveralls = ["coveralls_key"]
 out = ["Html", "Xml"]
 ```
 


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
I believe that the tarpaulin.toml config file example in the README should include [ ] around the features