### PR TITLE
Don't report coverage when not running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ file.
 ### Added
 
 ### Changed
+- Don't report coverage when not running tests
 
 ### Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,16 +90,18 @@ pub fn run(configs: &[Config]) -> Result<(), RunError> {
         }
     }
     if configs.len() == 1 {
-        report_coverage(&configs[0], &tracemap)?;
+        if !configs[0].no_run {
+            report_coverage(&configs[0], &tracemap)?;
+        }
     } else if !configs.is_empty() {
         let mut reported = false;
         for c in configs.iter() {
-            if c.name == "report" {
+            if !c.no_run && c.name == "report" {
                 reported = true;
                 report_coverage(c, &tracemap)?;
             }
         }
-        if !reported {
+        if configs[0].no_run && !reported {
             report_coverage(&configs[0], &tracemap)?;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub fn run(configs: &[Config]) -> Result<(), RunError> {
                 report_coverage(c, &tracemap)?;
             }
         }
-        if configs[0].no_run && !reported {
+        if !configs[0].no_run && !reported {
             report_coverage(&configs[0], &tracemap)?;
         }
     }


### PR DESCRIPTION
When using `--no-run` no coverage should be reported since no tests has been executed.