### PR TITLE
add feature for using vendored openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.10.2+1.1.1g"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +508,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,9 @@ syn = { version = "1.0", features = ["full"]}
 toml = "0.5"
 walkdir = "2.3.1"
 
+[features]
+default = []
+vendored-openssl = ["git2/vendored-openssl"]
+
 [build-dependencies]
 rustc_version = "0.2"


### PR DESCRIPTION
Add a feature for using the `vendored-openssl` feature in `git2`. This will allow `openssl-sys` to compile OpenSSL from source: https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/Cargo.toml#L15

It is useful for installing tarpaulin on environments that don't have OpenSSL.