### PR TITLE
move to tracing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,7 +70,6 @@ dependencies = [
  "chrono",
  "clap",
  "coveralls-api",
- "env_logger",
  "fallible-iterator",
  "gimli",
  "git2",
@@ -69,7 +77,6 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log",
  "memmap",
  "nix",
  "object",
@@ -83,6 +90,8 @@ dependencies = [
  "serde_json",
  "syn",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -131,7 +140,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -205,19 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,15 +283,6 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
@@ -306,7 +293,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
- "humantime 2.0.1",
+ "humantime",
  "serde",
 ]
 
@@ -406,6 +393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -522,6 +518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe74897791e156a0cd8cce0db31b9b2198e67877316bf3086c3acd187f719f0"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,12 +537,6 @@ checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -576,6 +572,16 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -681,6 +687,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
 name = "socket2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,15 +734,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -765,6 +777,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ cargo_metadata = "0.11"
 chrono = "0.4"
 clap = "2.33.3"
 coveralls-api = "0.5.0"
-env_logger = "0.7"
 fallible-iterator = "0.2.0"
 gimli = "0.22.0"
 git2 = "0.13"
@@ -32,7 +31,8 @@ humantime-serde = "1"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
 lazy_static = "1.0"
 libc = "0.2.77"
-log = "0.4.11"
+tracing = { version = "0.1", default-features = false }
+tracing-subscriber = {version = "0.2.3", default-features = false, features = ["env-filter", "fmt", "chrono", "ansi", "smallvec", "tracing-log"]}
 memmap = "0.7.0"
 nix = "0.18.0"
 object = "0.21"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -2,7 +2,6 @@ use crate::config::*;
 use crate::errors::RunError;
 use crate::path_utils::get_source_walker;
 use cargo_metadata::{diagnostic::DiagnosticLevel, CargoOpt, Message, Metadata, MetadataCommand};
-use log::{error, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -11,6 +10,7 @@ use std::io;
 use std::io::{BufRead, BufReader};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
+use tracing::{error, trace, warn};
 use walkdir::{DirEntry, WalkDir};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,6 @@ use clap::{value_t, ArgMatches};
 use coveralls_api::CiService;
 use humantime_serde::deserialize as humantime_serde;
 use indexmap::IndexMap;
-use log::{error, info, warn};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::cell::{Ref, RefCell};
@@ -16,6 +15,7 @@ use std::fs::File;
 use std::io::{Error, ErrorKind, Read};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use tracing::{error, info, warn};
 
 mod parse;
 pub mod types;

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -1,7 +1,6 @@
 use crate::config::types::*;
 use clap::{value_t, values_t, ArgMatches};
 use coveralls_api::CiService;
-use log::error;
 use regex::Regex;
 use serde::de::{self, Deserializer};
 use std::env;
@@ -10,6 +9,7 @@ use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
+use tracing::error;
 
 pub(super) fn get_list(args: &ArgMatches, key: &str) -> Vec<String> {
     args.values_of_lossy(key).unwrap_or_else(Vec::new)

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -2,13 +2,13 @@ use crate::cargo::TestBinary;
 use crate::ptrace_control::*;
 use crate::statemachine::{ProcessInfo, TracerAction};
 use chrono::offset::Local;
-use log::{info, warn};
 use nix::libc::*;
 use nix::sys::{signal::Signal, wait::WaitStatus};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::fs::File;
 use std::path::Path;
+use tracing::{info, warn};
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@ use crate::source_analysis::{LineAnalysis, SourceAnalysis};
 use crate::statemachine::*;
 use crate::test_loader::*;
 use crate::traces::*;
-use log::{error, info, trace, warn};
 use nix::unistd::*;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::CString;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
+use tracing::{error, info, trace, warn};
 
 pub mod branching;
 pub mod breakpoint;

--- a/src/report/coveralls.rs
+++ b/src/report/coveralls.rs
@@ -2,10 +2,10 @@ use crate::config::Config;
 use crate::errors::RunError;
 use crate::traces::{CoverageStat, TraceMap};
 use coveralls_api::*;
-use log::{info, trace, warn};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use tracing::{info, trace, warn};
 
 fn get_git_info(manifest_path: &Path) -> Result<GitInfo, String> {
     let dir_path = manifest_path

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -2,10 +2,10 @@ use crate::config::*;
 use crate::errors::*;
 use crate::test_loader::TracerData;
 use crate::traces::*;
-use log::{error, info};
 use serde::Serialize;
 use std::fs::{create_dir_all, File};
 use std::io::BufReader;
+use tracing::{error, info};
 
 pub mod cobertura;
 pub mod coveralls;

--- a/src/source_analysis/mod.rs
+++ b/src/source_analysis/mod.rs
@@ -2,7 +2,6 @@ use crate::branching::BranchAnalysis;
 use crate::config::{Config, RunType};
 use crate::path_utils::{get_source_walker, is_source_file};
 use lazy_static::lazy_static;
-use log::trace;
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use regex::Regex;
@@ -13,6 +12,7 @@ use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use syn::spanned::Spanned;
 use syn::*;
+use tracing::trace;
 use walkdir::WalkDir;
 
 mod attributes;

--- a/src/statemachine/linux.rs
+++ b/src/statemachine/linux.rs
@@ -2,13 +2,13 @@ use crate::config::Config;
 use crate::errors::RunError;
 use crate::event_log::*;
 use crate::statemachine::*;
-use log::{debug, trace};
 use nix::errno::Errno;
 use nix::sys::signal::Signal;
 use nix::sys::wait::*;
 use nix::unistd::Pid;
 use nix::Error as NixErr;
 use std::collections::{HashMap, HashSet};
+use tracing::{debug, trace};
 
 pub fn create_state_machine<'a>(
     test: Pid,

--- a/src/statemachine/mod.rs
+++ b/src/statemachine/mod.rs
@@ -3,8 +3,8 @@ use crate::config::Config;
 use crate::errors::RunError;
 use crate::ptrace_control::*;
 use crate::traces::*;
-use log::error;
 use std::time::Instant;
+use tracing::error;
 
 #[cfg(target_os = "linux")]
 pub mod linux;

--- a/src/test_loader.rs
+++ b/src/test_loader.rs
@@ -4,7 +4,6 @@ use crate::source_analysis::*;
 use crate::traces::*;
 use gimli::read::Error;
 use gimli::*;
-use log::{debug, error, trace};
 use memmap::MmapOptions;
 use object::{read::ObjectSection, File as OFile, Object};
 use rustc_demangle::demangle;
@@ -12,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
+use tracing::{debug, error, trace};
 
 /// Describes a function as `low_pc`, `high_pc` and bool representing `is_test`.
 type FuncDesc = (u64, u64, FunctionType, Option<String>);

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -1,4 +1,3 @@
-use log::trace;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ord, Ordering};
 use std::collections::btree_map::Iter;
@@ -6,6 +5,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Display, Formatter, Result};
 use std::ops::Add;
 use std::path::{Path, PathBuf};
+use tracing::trace;
 
 /// Used to track the state of logical conditions
 #[derive(Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Deserialize, Serialize)]


### PR DESCRIPTION
- replace `use log::{..}` with `use tracing::{..}`
- replace the env_logger with tracing-subscriber
- keep most of the behavior (variables debug and verbose) which set the default tracing mode.
- CHANGE BEHAVIOR: RUST_LOG now can overwrite debug and verbose, you can also use it to overwrite it only partially
(i wasn't able to run all the tests locally)
(maybe we need to `tracing-log` crate, in order to capture dependencies logs)


<!--- Please describe the changes in the PR and them motivation below -->
First steps of #545 . It still needs a check if the current logging is good.

Also note:
- I had serious problems running tarpaulins tests. So i can't say if it works perfectly.
- removed a useless `use std::io::Write;`

![image](https://user-images.githubusercontent.com/5282251/94534520-c5862f00-0240-11eb-9c14-3bb9feb92135.png)
