### PR TITLE
Add avoid-cfg-tarpaulin flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file.
 
 ## [Unreleased]
 ### Added
-- Added `--avoid-cfg-tarpaulin` flag to remove --cfg=tarpaulin from the RUSTFLAGS
+- Added `--avoid-cfg-tarpaulin` flag to remove `--cfg=tarpaulin` from the `RUSTFLAGS`
 
 ### Changed
 - Address offset mapping has been added which allows us to compile binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ file.
 
 ## [Unreleased]
 ### Added
+- Added `--avoid-cfg-tarpaulin` flag to remove --cfg=tarpaulin from the RUSTFLAGS
 
 ### Changed
 - Address offset mapping has been added which allows us to compile binaries

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -441,7 +441,10 @@ pub fn rustdoc_flags(config: &Config) -> String {
 
 pub fn rust_flags(config: &Config) -> String {
     const RUSTFLAGS: &str = "RUSTFLAGS";
-    let mut value = " -C link-dead-code -C debuginfo=2 --cfg=tarpaulin ".to_string();
+    let mut value = " -C link-dead-code -C debuginfo=2 ".to_string();
+    if !config.avoid_cfg_tarpaulin {
+        value = format!("{}--cfg=tarpaulin ", value);
+    }
     if config.release {
         value = format!("{}-C debug-assertions=off ", value);
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -157,6 +157,8 @@ pub struct Config {
     /// Result of cargo_metadata ran on the crate
     #[serde(skip_deserializing, skip_serializing)]
     pub metadata: RefCell<Option<Metadata>>,
+    /// Don't pass --cfg=tarpaulin to the 'RUSTFLAG'
+    pub avoid_cfg_tarpaulin: bool,
 }
 
 fn default_test_timeout() -> Duration {
@@ -215,6 +217,7 @@ impl Default for Config {
             profile: None,
             fail_under: None,
             metadata: RefCell::new(None),
+            avoid_cfg_tarpaulin: false,
         }
     }
 }
@@ -284,6 +287,7 @@ impl<'a> From<&'a ArgMatches<'a>> for ConfigWrapper {
             fail_under: value_t!(args.value_of("fail-under"), f64).ok(),
             profile: get_profile(args),
             metadata: RefCell::new(None),
+            avoid_cfg_tarpaulin: args.is_present("avoid-cfg-tarpaulin"),
         };
         if args.is_present("ignore-config") {
             Self(vec![args_config])

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ fn main() -> Result<(), String> {
                  --offline 'Run without accessing the network'
                  --print-rust-flags 'Print the RUSTFLAGS options that tarpaulin will compile your program with and exit'
                  --print-rustdoc-flags 'Print the RUSTDOCFLAGS options that tarpaulin will compile any doctests with and exit'
+                 --avoid-cfg-tarpaulin 'Remove --cfg=tarpaulin from the RUSTFLAG'
                  -Z [FEATURES]...   'List of unstable nightly only flags'")
             .args(&[
                 Arg::from_usage("--out -o [FMT]   'Output format of coverage report'")


### PR DESCRIPTION
I created this pull request in order to avoid "cannot find attribute" error that comes from `#[cfg_attr(tarpaulin, skip)]` in some old dependencies.
In the project I use `glutin` that uses `wayland-commons v0.21.13`. When I want to check coverage using tarpaulin I get:

> "Error: cannot find attribute \`skip\` in this scope"

`--avoid-cfg-tarpaulin` flag removes `--cfg=tarpaulin` from the `RUSTFLAGS`.
Do you agree to add such a flag?
Thanks in advance.