### PR TITLE
Workspace naming convention seems to have changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ file.
 - Pass through the non-zero exit code from cargo (issue #627)
 - Change doctest source resolution to accommodate for binary renaming in nightly
 1.50.0
+- Changed path prefix in doctests to go from workspace package root not project root
 
 ### Removed
 


### PR DESCRIPTION
Now trying to match on a minimal representation of the path

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
