### PR TITLE
Source location traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ file.
 - Change doctest source resolution to accommodate for binary renaming in nightly
 1.50.0
 - Changed path prefix in doctests to go from workspace package root not project root
+- Added source location to debug event logs
 
 ### Removed
 

--- a/src/statemachine/linux.rs
+++ b/src/statemachine/linux.rs
@@ -203,7 +203,12 @@ impl<'a> StateData for LinuxData<'a> {
             let span = trace_span!("pending", event=?status.pid());
             let _enter = span.enter();
             if let Some(log) = self.event_log.as_ref() {
-                let event = TraceEvent::new_from_wait(&status);
+                let offset = if let Some(process) = self.get_traced_process_mut(self.current) {
+                    process.offset
+                } else {
+                    0
+                };
+                let event = TraceEvent::new_from_wait(&status, offset, self.traces);
                 log.push_trace(event);
             }
             let state = match status {

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -75,6 +75,14 @@ pub struct Trace {
     pub fn_name: Option<String>,
 }
 
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Location {
+    /// Source file
+    pub file: PathBuf,
+    /// Source line
+    pub line: u64,
+}
+
 impl Trace {
     pub fn new(line: u64, address: HashSet<u64>, length: usize, fn_name: Option<String>) -> Self {
         Self {
@@ -299,6 +307,21 @@ impl TraceMap {
         for val in self.all_traces_mut() {
             if val.address.contains(&address) {
                 return Some(val);
+            }
+        }
+        None
+    }
+
+    pub fn get_location(&self, address: u64) -> Option<Location> {
+        for (k, v) in &self.traces {
+            if let Some(s) = v
+                .iter()
+                .find(|x| x.address.iter().any(|x| (*x & !0x7u64) == address))
+            {
+                return Some(Location {
+                    file: k.to_path_buf(),
+                    line: s.line,
+                });
             }
         }
         None


### PR DESCRIPTION
In the debug logs add some source information just so I can see which
lines are hit in what order. Initial impl

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
