### PR TITLE
Fixes #601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ file.
 - Added `--color` option matching cargo arg
 - `--follow-exec` option making exec tracing non-default
 - `--jobs` option matching the one in cargo test
+- Check if user sets -Cdebuginfo and remove it #601
 
 ### Changed
 - Check through memory map for the first entry belonging to the executable [FIX]

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -2,6 +2,8 @@ use crate::config::*;
 use crate::errors::RunError;
 use crate::path_utils::get_source_walker;
 use cargo_metadata::{diagnostic::DiagnosticLevel, CargoOpt, Message, Metadata, MetadataCommand};
+use lazy_static::lazy_static;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -479,7 +481,10 @@ pub fn rust_flags(config: &Config) -> String {
         value = format!("{}-C debug-assertions=off ", value);
     }
     if let Ok(vtemp) = env::var(RUSTFLAGS) {
-        value.push_str(vtemp.as_ref());
+        lazy_static! {
+            static ref DEBUG_INFO: Regex = Regex::new(r#"\-C\s*debuginfo=\d"#).unwrap();
+        }
+        value.push_str(&DEBUG_INFO.replace_all(&vtemp, " "));
     }
     value
 }

--- a/tests/line_coverage.rs
+++ b/tests/line_coverage.rs
@@ -45,3 +45,24 @@ fn simple_project_coverage() {
         }
     }
 }
+
+#[test]
+fn debug_info_0() {
+    // From issue #601
+    let mut config = Config::default();
+    let restore_dir = env::current_dir().unwrap();
+    let test_dir = get_test_path("simple_project");
+    env::set_current_dir(&test_dir).unwrap();
+    config.manifest = test_dir.clone();
+    config.manifest.push("Cargo.toml");
+    let backup_flag = env::var("RUSTFLAGS").ok();
+    env::set_var("RUSTFLAGS", "-Cdebuginfo=0");
+    let (res, ret) = launch_tarpaulin(&config, &None).unwrap();
+    match backup_flag {
+        None => env::remove_var("RUSTFLAGS"),
+        Some(s) => env::set_var("RUSTFLAGS", s),
+    };
+    assert_eq!(ret, 0);
+    assert!(!res.is_empty());
+    env::set_current_dir(restore_dir).unwrap();
+}


### PR DESCRIPTION
This detects if the user has set -Cdebuginfo in their rustflags and
removes this as tarpaulin sets it and requires it to get debug info for
traces.

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
