### PR TITLE
Fix path comparison in windows

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -833,7 +833,8 @@ mod tests {
 
         let path_a = Path::new("/this/should/not/form/a/rel/path/");
         let path_b = Path::new("this/should/not/form/a/rel/path/");
-
+        assert!(!path_b.is_absolute());
+        assert!(path_a.is_absolute());
         let rel_path = path_relative_from(path_b, path_a);
         assert_eq!(rel_path, None, "Did not expect relative path");
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -832,13 +832,13 @@ mod tests {
         );
 
         let path_a = Path::new("/this/should/not/form/a/rel/path/");
-        let path_b = Path::new("./this/should/not/form/a/rel/path/");
+        let path_b = Path::new("this/should/not/form/a/rel/path/");
 
         let rel_path = path_relative_from(path_b, path_a);
         assert_eq!(rel_path, None, "Did not expect relative path");
 
-        let path_a = Path::new("./this/should/form/a/rel/path/");
-        let path_b = Path::new("./this/should/form/b/rel/path/");
+        let path_a = Path::new("this/should/form/a/rel/path/");
+        let path_b = Path::new("this/should/form/b/rel/path/");
 
         let rel_path = path_relative_from(path_b, path_a);
         assert!(rel_path.is_some());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -820,10 +820,17 @@ mod tests {
 
     #[test]
     fn relative_path_test() {
-        let path_a = Path::new("/this/should/form/a/rel/path/");
-        let path_b = Path::new("/this/should/form/b/rel/path/");
+        cfg_if::cfg_if! {
+            if #[cfg(windows)] {
+                let root_base = "C:";
+            } else {
+                let root_base = "";
+            }
+        }
+        let path_a = PathBuf::from(format!("{}/this/should/form/a/rel/path/", root_base));
+        let path_b = PathBuf::from(format!("{}/this/should/form/b/rel/path/", root_base));
 
-        let rel_path = path_relative_from(path_b, path_a);
+        let rel_path = path_relative_from(&path_b, &path_a);
         assert!(rel_path.is_some());
         assert_eq!(
             rel_path.unwrap(),
@@ -831,11 +838,11 @@ mod tests {
             "Wrong relative path"
         );
 
-        let path_a = Path::new("/this/should/not/form/a/rel/path/");
+        let path_a = PathBuf::from(format!("{}/this/should/not/form/a/rel/path/", root_base));
         let path_b = Path::new("this/should/not/form/a/rel/path/");
         assert!(!path_b.is_absolute());
         assert!(path_a.is_absolute());
-        let rel_path = path_relative_from(path_b, path_a);
+        let rel_path = path_relative_from(path_b, &path_a);
         assert_eq!(rel_path, None, "Did not expect relative path");
 
         let path_a = Path::new("this/should/form/a/rel/path/");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -826,8 +826,8 @@ mod tests {
         let rel_path = path_relative_from(path_b, path_a);
         assert!(rel_path.is_some());
         assert_eq!(
-            rel_path.unwrap().to_str().unwrap(),
-            "../../../b/rel/path",
+            rel_path.unwrap(),
+            Path::new("../../../b/rel/path"),
             "Wrong relative path"
         );
 
@@ -843,8 +843,8 @@ mod tests {
         let rel_path = path_relative_from(path_b, path_a);
         assert!(rel_path.is_some());
         assert_eq!(
-            rel_path.unwrap().to_str().unwrap(),
-            "../../../b/rel/path",
+            rel_path.unwrap(),
+            Path::new("../../../b/rel/path"),
             "Wrong relative path"
         );
     }

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -80,11 +80,22 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(unix)]
     fn system_headers_not_coverable() {
         assert!(!is_coverable_file_path(
             "/usr/include/c++/9/iostream",
             "/home/ferris/rust/project",
             "/home/ferris/rust/project/target"
+        ));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn system_headers_not_coverable() {
+        assert!(!is_coverable_file_path(
+            "C:/Program Files/Visual Studio/include/c++/9/iostream",
+            "C:/User/ferris/rust/project",
+            "C:/User/ferris/rust/project/target"
         ));
     }
 


### PR DESCRIPTION
Comparing path equality with strings wasn't smart now was it

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
