### PR TITLE
initial implementation rustflags arg #689

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ file.
 compiler support. This isn't enabled so should have no effect it's just the
 start of the support work.
 - Now factors in rustflags from toml files #528
+- Now able to add to rustflags via CLI args and via tarpaulin config files
 
 ### Changed
 - Make doctest prefix matching less specific as the naming convention changed again

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -640,7 +640,8 @@ fn gather_config_rust_flags(config: &Config) -> String {
 
 pub fn rust_flags(config: &Config) -> String {
     const RUSTFLAGS: &str = "RUSTFLAGS";
-    let mut value = " -C link-dead-code -C debuginfo=2 ".to_string();
+    let mut value = config.rustflags.clone().unwrap_or_default();
+    value.push_str(" -C link-dead-code -C debuginfo=2 ");
     if !config.avoid_cfg_tarpaulin {
         value.push_str("--cfg=tarpaulin ");
     }

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -62,6 +62,10 @@ pub(super) fn get_target(args: &ArgMatches) -> Option<String> {
     args.value_of("target").map(String::from)
 }
 
+pub(super) fn get_rustflags(args: &ArgMatches) -> Option<String> {
+    args.value_of("rustflags").map(String::from)
+}
+
 pub(super) fn get_target_dir(args: &ArgMatches) -> Option<PathBuf> {
     let path = if let Some(path) = args.value_of("target-dir") {
         PathBuf::from(path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ fn main() -> Result<(), String> {
                  --print-rustdoc-flags 'Print the RUSTDOCFLAGS options that tarpaulin will compile any doctests with and exit'
                  --avoid-cfg-tarpaulin 'Remove --cfg=tarpaulin from the RUSTFLAG'
                  -j --jobs [N] 'Number of parallel jobs, defaults to # of CPUs'
+                 --rustflags [FLAGS] 'rustflags to add when building project (can also be set via RUSTFLAGS env var)'
                  -Z [FEATURES]...   'List of unstable nightly only flags'")
             .args(&[
                 Arg::from_usage("--out -o [FMT]   'Output format of coverage report'")


### PR DESCRIPTION
Allow rustflags to be passed via arg and therefore via config file