### PR TITLE
Reduce the number of the cleans for #747

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ file.
 - Don't apply `--color` argument to test executables if "auto" to prevent issues
 with tests that can't have color controlled
 - Fix directory that `cargo clean` is run from
+- Reduce number of cleans fixing issue where only last run-type was ran
+- Clean without `cargo clean` removing directory to preserve coverage run delta reporting
 
 ### Removed
 

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -41,6 +41,7 @@ pub fn get_test_coverage(
     logger: &Option<EventLog>,
 ) -> Result<Option<(TraceMap, i32)>, RunError> {
     if !test.path().exists() {
+        warn!("Test at {} doesn't exist", test.path().display());
         return Ok(None);
     }
     if let Err(e) = limit_affinity() {

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -5,6 +5,34 @@ use std::env;
 use std::time::Duration;
 
 #[test]
+fn mix_test_types() {
+    // Issue 747 the clean would delete old tests leaving to only one run type effectively being
+    // ran. This test covers against that mistake
+    let mut config = Config::default();
+    config.force_clean = true;
+    config.test_timeout = Duration::from_secs(60);
+    config.run_types = vec![RunType::Tests, RunType::Examples];
+    let restore_dir = env::current_dir().unwrap();
+    let test_dir = get_test_path("all_test_types");
+    env::set_current_dir(&test_dir).unwrap();
+    config.manifest = test_dir;
+    config.manifest.push("Cargo.toml");
+
+    let (res, ret) = launch_tarpaulin(&config, &None).unwrap();
+    assert_eq!(ret, 0);
+    env::set_current_dir(restore_dir).unwrap();
+
+    for f in res.files() {
+        let f_name = f.file_name().unwrap().to_str().unwrap();
+        if f_name.contains("example") || (f_name.contains("test") && !f_name.contains("doc")) {
+            assert!(res.covered_in_path(f) > 0);
+        } else {
+            assert_eq!(res.covered_in_path(f), 0);
+        }
+    }
+}
+
+#[test]
 fn only_test_coverage() {
     let mut config = Config::default();
     config.force_clean = false;


### PR DESCRIPTION
Also noticed that the default cleaning deletes the whole target irectory
including the previous tarpaulin results. So moved to deleting just the
artefact folders so between run deltas are still reported

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
