### PR TITLE
Fix cleaning for wrong directory

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -165,9 +165,9 @@ pub fn get_tests(config: &Config) -> Result<Vec<TestBinary>, RunError> {
     let mut result = vec![];
     if config.force_clean {
         let cleanup_dir = if config.release {
-            config.target_dir().join("debug")
-        } else {
             config.target_dir().join("release")
+        } else {
+            config.target_dir().join("debug")
         };
         info!("Cleaning project");
         if cleanup_dir.exists() {


### PR DESCRIPTION
I think it there is no Easter egg for `cargo` to put release build in `${CARGO_TARGET_DIR}/debug`
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
