### PR TITLE
Fixes #797

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ file.
 
 ### Changed
 - `--verbose` now calls cargo with `-v` flag
+- Now handles string values for rustflags in .cargo/config not just a list of values
 
 ### Removed
 


### PR DESCRIPTION
Handles instance where rustflags can be a string instead of just a list

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
