### PR TITLE
feat(config): log config parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ file.
 - `--verbose` now calls cargo with `-v` flag
 - Now handles string values for rustflags in .cargo/config not just a list of values
 - INTERNAL If llvm coverage is enabled and test binary can't be loaded start with empty `TraceMap`
+- Config parse errors are logged
 
 ### Removed
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,6 +20,8 @@ use tracing::{error, info, warn};
 mod parse;
 pub mod types;
 
+#[derive(Debug)]
+
 pub struct ConfigWrapper(pub Vec<Config>);
 
 /// Specifies the current configuration tarpaulin is using.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,7 +21,6 @@ mod parse;
 pub mod types;
 
 #[derive(Debug)]
-
 pub struct ConfigWrapper(pub Vec<Config>);
 
 /// Specifies the current configuration tarpaulin is using.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use cargo_tarpaulin::config::{
     Color, Config, ConfigWrapper, Mode, OutputFile, RunType, TraceEngine,
 };
 use cargo_tarpaulin::{run, setup_logging};
-use clap::{crate_version, App, Arg, ArgSettings, SubCommand};
+use clap::{crate_version, value_t, App, Arg, ArgSettings, SubCommand};
 use std::collections::HashMap;
 use std::path::Path;
 use tracing::{info, trace};
@@ -135,12 +135,15 @@ fn main() -> Result<(), String> {
 
     let args = args.subcommand_matches("tarpaulin").unwrap_or(&args);
 
-    let config = ConfigWrapper::from(args);
     setup_logging(
-        config.0[0].color,
+        value_t!(args.value_of("color"), Color).unwrap_or(Color::Auto),
         args.is_present("debug"),
         args.is_present("verbose"),
     );
+    let config = ConfigWrapper::from(args);
+
+    trace!("Config vector: {:#?}", config);
+
     let mut run_coverage = true;
     if args.is_present("print-rust-flags") {
         run_coverage = false;


### PR DESCRIPTION
This change allows to see config parse errors. Entire conf vector is also dumped for additional verification if `trace` enabled.

The motivation for this PR is that it is quite difficult to get the configuration file correctly quickly as parse errors will not be reported. I encountered this problem while trying to write a config file, where I needed to combine several `cargo test` runs into a single coverage report.