### PR TITLE
Expand gitlab section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,11 +444,32 @@ jobs:
 ### Gitlab Pipelines
 
 To get the coverage results showing up in your Gitlab pipelines add the following regex to the `Test
-coverage parsing` section in the pipelines settings.
+coverage parsing` section in the CI/CD settings.
 
 ```yml
 ^\d+.\d+% coverage
 ```
+
+Or add the regex to the job definition in `.gitlab-ci.yml`:
+
+```yml
+job: ...
+  coverage: '/^\d+.\d+% coverage/'
+```
+
+Gitlab can [show coverage information] in the diff of a merge request. For that, use
+
+```yml
+job: ...
+  artifacts:
+    reports:
+      cobertura:
+        - cobertura.xml
+```
+
+and generate a `cobertura.xml` as described under [Pycobertura](#pycobertura).
+
+  [show coverage information]: https://docs.gitlab.com/ee/user/project/merge_requests/test_coverage_visualization.html
 
 For installation add `cargo install cargo-tarpaulin -f` to the script section.
 


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
Thanks for the great tool!

I just set up my project for coverage reports with `tarpaulin`, and found I can do more than the README.md lets on, so here we go :)

- Add instructions how to set up highlighting coverage status of lines in Gitlab MRs.
- Describe another way to specify the coverage regex for a specific job, in `gitlab-ci.yml`. 