### PR TITLE
Use core from existing mask when setting processor affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ file.
 - Now handles string values for rustflags in .cargo/config not just a list of values
 - INTERNAL If llvm coverage is enabled and test binary can't be loaded start with empty `TraceMap`
 - Config parse errors are logged
+- Setting the processor affinity now uses an existing core from the initial affinity mask instead of defaulting to the first one (see issue #817)
 
 ### Removed
 


### PR DESCRIPTION
As discussed in #817, this change sets the processor affinity to the lowest core id of the existing affinity mask. This will solve cases where the core id 0, which was previously used, is not available (e.g. in virtualized environments).
(fixes #817)