### PR TITLE
Add support for binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,8 @@ vendored-openssl = ["git2/vendored-openssl"]
 
 [build-dependencies]
 rustc_version = "0.4"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ version }-travis.tar.gz"
+bin-dir = "cargo-tarpaulin"
+pkg-fmt = "tgz"

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ installation and massively reducing the install time on CI.
 When using the [Nix](https://nixos.org/nix) package manager, the `nixpkgs.cargo-tarpaulin` package can be used.
 This ensures that tarpaulin will be built with the same rust version as the rest of your packages.
 
+You can also use [cargo-binstall](https://github.com/ryankurte/cargo-binstall):
+
+```text
+cargo binstall cargo-tarpaulin
+```
+
 ### Environment Variables
 
 When tarpaulin runs your tests it strives to run them in the same environment as if they were ran via cargo test. 


### PR DESCRIPTION
As per (I think): https://twitter.com/xd009642/status/1435639358531452928

For context:

Cargo Binstall provides a one-stop tool to install binaries from the CLI. It's a bit rough around the edges but works well in most cases. This PR adds the metadata needed to get it going (from the next release)!

To test this before the next release / cargo publish:

```
cd repo
git checkout the branch
cargo binstall --manifest-path . --log-level debug cargo-tarpaulin
```