### PR TITLE
Update README as codecov action v1 is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ jobs:
           cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
 
       - name:                   Upload to codecov.io
-        uses:                   codecov/codecov-action@v1
+        uses:                   codecov/codecov-action@v2
         with:
           # token:                ${{secrets.CODECOV_TOKEN}} # not required for public repos
           fail_ci_if_error:     true


### PR DESCRIPTION
See also: https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
