### PR TITLE
feat: Add unstable `#[no_coverage]` attribute to ignore set

### DIFF
--- a/src/source_analysis/attributes.rs
+++ b/src/source_analysis/attributes.rs
@@ -35,7 +35,10 @@ impl SourceAnalysis {
 pub(crate) fn check_cfg_attr(attr: &Meta) -> bool {
     let mut ignore_span = false;
     let id = attr.path();
-    if id.is_ident("cfg") {
+
+    if id.is_ident("no_coverage") {
+        ignore_span = true;
+    } else if id.is_ident("cfg") {
         if let Meta::List(ml) = attr {
             'outer: for p in ml.nested.iter() {
                 if let NestedMeta::Meta(Meta::List(ref i)) = p {

--- a/src/source_analysis/tests.rs
+++ b/src/source_analysis/tests.rs
@@ -809,6 +809,11 @@ fn tarpaulin_skip_attr() {
         fn uncovered2() {
             println!(\"oof\");
         }
+
+        #[no_coverage]
+        fn uncovered3() {
+            println!(\"zombie lincoln\");
+        }
         ",
         file: Path::new(""),
         ignore_mods: RefCell::new(HashSet::new()),
@@ -825,6 +830,8 @@ fn tarpaulin_skip_attr() {
     assert!(lines.ignore.contains(&Lines::Line(13)));
     assert!(lines.ignore.contains(&Lines::Line(17)));
     assert!(lines.ignore.contains(&Lines::Line(18)));
+    assert!(lines.ignore.contains(&Lines::Line(22)));
+    assert!(lines.ignore.contains(&Lines::Line(23)));
 
     let ctx = Context {
         config: &config,


### PR DESCRIPTION
This adds the unstable rustc attribute for skipping coverage of items.

Fixes #860.