### PR TITLE
Fix the build on aarch64-unknown-linux-gnu

### DIFF
--- a/src/process_handling/breakpoint.rs
+++ b/src/process_handling/breakpoint.rs
@@ -4,7 +4,7 @@ use nix::unistd::Pid;
 use nix::{Error, Result};
 use std::collections::HashMap;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 const INT: u64 = 0xCC;
 
 /// Breakpoint construct used to monitor program execution. As tarpaulin is an

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -13,7 +13,12 @@ use std::ffi::{CStr, CString};
 use std::path::Path;
 use tracing::{info, warn};
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64"
+))]
 type Persona = c_long;
 
 const ADDR_NO_RANDOMIZE: Persona = 0x004_0000;


### PR DESCRIPTION
`Persona` and `INT` are cfg-gated thus the build on aarch64-unknown-linux-gnu fails. I think the functionality should also work on AArch64 so added `aarch64` to the `cfg`s.