### PR TITLE
Exclude files already when walking source tree

### DIFF
--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -64,7 +64,7 @@ pub fn is_coverable_file_path(
     ignorable_paths && is_part_of_project(e, root.as_ref())
 }
 
-pub fn get_source_walker(config: &Config) -> impl Iterator<Item = DirEntry> {
+pub fn get_source_walker(config: &Config) -> impl Iterator<Item = DirEntry> + '_ {
     let root = config.root();
     let target = config.target_dir();
 
@@ -72,6 +72,7 @@ pub fn get_source_walker(config: &Config) -> impl Iterator<Item = DirEntry> {
     walker
         .filter_entry(move |e| is_coverable_file_path(e.path(), &root, &target))
         .filter_map(|e| e.ok())
+        .filter(move |e| !(config.exclude_path(e.path())))
         .filter(|e| is_source_file(e))
 }
 


### PR DESCRIPTION
It is known that `tarpaulin` will look for coverage data in vendored
crates if `cargo-vendor` is used (#210). It is reasonably simple to
exclude the vendored crates though the `--exclude-files` option.
However, all of the sources is still collected even if they are not
treated as covered. This is quite obvious when using the `Html` report
format for example which becomes huge because it contains the crate
sources as well as all the vendored crates' source files.

To avoid this, apply the excluded files filter at the earliest point,
i.e., when walking the crate source tree and finding all the rust source
files.


---

Small example:
```bash
cargo new tarpaulin-vendor-reprod
```
`Cargo.toml`:
```toml
  [package]
  name = "tarpaulin-vendor-reprod"
  version = "0.1.0"
  edition = "2021"

  [dependencies]
  heapless = "0.7"
```
Vendoring:
```bash
cargo vendor > .cargo/config
```

Sample code:
```rust
use heapless::Vec;

fn foo<const N: usize>(bar: Vec<u32, N>) -> u32 {
    bar.iter().sum()
}

#[test]
fn test_foo() {
    let v: Vec<u32, 8> = Vec::from_slice(&[1, 2, 3]).unwrap();
    assert_eq!(foo(v), 6);
}
```

Run tarpaulin:
```bash
cargo tarpaulin --out Html --exclude-files vendor
```

Html report becomes 9MB (with two runs for comparison) compared to 140KB with the patch.