### PR TITLE
Implement pruning of flags to remove duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ file.
 
 ### Changed
 - Correct report line-rate in cobertura to use coverage percentage of `TraceMap` instead of averaging package line-rate
+- Parse RUSTFLAGS and RUSTDOCFLAGS to remove duplicate entries #891
 
 ### Removed
 

--- a/tests/data/rustflags/src/lib.rs
+++ b/tests/data/rustflags/src/lib.rs
@@ -7,5 +7,5 @@ fn ensure_rustflags_are_set() {
     
     let rust_flags: &'static str = env!("RUSTFLAGS");
 
-    assert!(rust_flags.to_string().contains("-C target-cpu=native"))
+    assert!(rust_flags.to_string().contains("target-cpu=native"))
 }


### PR DESCRIPTION
In theory this should improve incremental compilation via --skip-clean

Fixes #891 
