### PR TITLE
Enable INT and Persona type on RISC-V

### DIFF
--- a/src/process_handling/breakpoint.rs
+++ b/src/process_handling/breakpoint.rs
@@ -4,7 +4,7 @@ use nix::unistd::Pid;
 use nix::{Error, Result};
 use std::collections::HashMap;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "riscv64"))]
 const INT: u64 = 0xCC;
 
 /// Breakpoint construct used to monitor program execution. As tarpaulin is an

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -14,7 +14,7 @@ use std::ffi::{CStr, CString};
 use std::path::Path;
 use tracing::{info, warn};
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "riscv64"))]
 type Persona = c_long;
 
 lazy_static! {


### PR DESCRIPTION
This type is usable on RISC-V. This patch enable `riscv64` arch for building on RISC-V environment.