### PR TITLE
Remove LLVM codegen-units Windows workaround

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -566,9 +566,6 @@ fn clean_doctest_folder<P: AsRef<Path>>(doctest_dir: P) {
 fn handle_llvm_flags(value: &mut String, config: &Config) {
     if config.engine() == TraceEngine::Llvm {
         value.push_str("-Z instrument-coverage ");
-        if cfg!(windows) {
-            value.push_str("-C codegen-units=1 ");
-        }
     }
     if cfg!(not(windows)) {
         value.push_str(" -C link-dead-code ");


### PR DESCRIPTION
The workaround isn't needed anymore since https://github.com/rust-lang/rust/issues/85461 is now fixed on Nightly.

Working for me on `x86_64-pc-windows-msvc` and `1.59.0-nightly (fcef61230 2021-12-17)`