### PR TITLE
add additional test cases for 'no_run'

### DIFF
--- a/tests/data/doctest_norun/src/lib.rs
+++ b/tests/data/doctest_norun/src/lib.rs
@@ -9,3 +9,22 @@
 pub fn do_something() {
     todo!()
 }
+
+
+/// This function doesn't do much
+///
+/// ```rust,no_run
+/// panic!("Don't run me")
+/// ```
+pub fn do_something_else() {
+    todo!()
+}
+
+/// This function doesn't do much
+///
+/// ```rust no_run
+/// panic!("Don't run me")
+/// ```
+pub fn do_something_again() {
+    todo!()
+}


### PR DESCRIPTION
adds additional test cases to check that the 'no_run' attribute on doc-tests is properly respected even when there is also a `rust` tag

see #924 