### PR TITLE
Fixes #921

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ file.
 
 ### Changed
 - Support skip-clean in config files and implement prioritisation in merges
+- Fix issue where in a workspace wih different run types the package IDs can become misaligned with test binaries
 
 ## [0.19.0] 2021-12-27
 ### Added

--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -173,6 +173,8 @@ fn execute_test(
         None => env::set_current_dir(&config.root()),
     };
 
+    debug!("Current working dir: {:?}", env::current_dir());
+
     let mut envars: Vec<(String, String)> = Vec::new();
 
     for (key, value) in env::vars() {
@@ -222,8 +224,6 @@ fn execute_test(
     if test.has_linker_paths() {
         envars.push(("LD_LIBRARY_PATH".to_string(), test.ld_library_path()));
     }
-    debug!("Env vars: {:?}", envars);
-    debug!("Args: {:?}", argv);
     match config.engine() {
         TraceEngine::Llvm => {
             // Used for llvm coverage to avoid report naming clashes TODO could have clashes
@@ -232,6 +232,8 @@ fn execute_test(
                 "LLVM_PROFILE_FILE".to_string(),
                 format!("{}_%p.profraw", test.file_name()),
             ));
+            debug!("Env vars: {:?}", envars);
+            debug!("Args: {:?}", argv);
             let mut child = Command::new(test.path());
             child.envs(envars).args(&argv);
 
@@ -241,6 +243,8 @@ fn execute_test(
         #[cfg(target_os = "linux")]
         TraceEngine::Ptrace => {
             argv.insert(0, test.path().display().to_string());
+            debug!("Env vars: {:?}", envars);
+            debug!("Args: {:?}", argv);
             execute(test.path(), &argv, envars.as_slice())
         }
         e => Err(RunError::Engine(format!(


### PR DESCRIPTION
The results vector is already passed into `run_cargo` so the package id
vector can be misaligned

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
