### PR TITLE
use lossless conversions where available

### DIFF
--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -93,7 +93,7 @@ impl TraceEvent {
         match wait {
             WaitStatus::Exited(_, i) => {
                 event.description = "Exited".to_string();
-                event.return_val = Some(*i as _);
+                event.return_val = Some((*i).into());
             }
             WaitStatus::Signaled(_, sig, _) => {
                 event.signal = Some(sig.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ pub fn launch_tarpaulin(
             if let Some(res) = coverage {
                 result.merge(&res.0);
                 return_code |= if exe.should_panic() {
-                    (res.1 == 0) as i32
+                    (res.1 == 0).into()
                 } else {
                     res.1
                 };

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -151,11 +151,11 @@ pub fn amount_covered(traces: &[&Trace]) -> usize {
     let mut result = 0usize;
     for t in traces {
         result += match t.stats {
-            CoverageStat::Branch(ref x) => (x.been_true as usize) + (x.been_false as usize),
+            CoverageStat::Branch(ref x) => usize::from(x.been_true) + usize::from(x.been_false),
             CoverageStat::Condition(ref x) => x.iter().fold(0, |acc, x| {
-                acc + (x.been_true as usize) + (x.been_false as usize)
+                acc + usize::from(x.been_true) + usize::from(x.been_false)
             }),
-            CoverageStat::Line(ref x) => (*x > 0) as usize,
+            CoverageStat::Line(ref x) => (*x > 0).into(),
         };
     }
     result


### PR DESCRIPTION
remove unnecessary casts