### PR TITLE
remove mutable double reference

### DIFF
--- a/src/statemachine/linux.rs
+++ b/src/statemachine/linux.rs
@@ -635,7 +635,7 @@ impl<'a> LinuxData<'a> {
                 let rip = (rip - 1) as u64;
                 trace!("Hit address 0x{:x}", rip);
                 if process.breakpoints.contains_key(&rip) {
-                    let bp = &mut process.breakpoints.get_mut(&rip).unwrap();
+                    let bp = process.breakpoints.get_mut(&rip).unwrap();
                     let updated = if visited.contains(&rip) {
                         let _ = bp.jump_to(current);
                         (true, TracerAction::Continue(current.into()))


### PR DESCRIPTION
this line creates a mutable reference to a mutable reference. this can be flattened