### PR TITLE
Change merging of force-clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ file.
 - Continue vfork parents so test execution isn't stalled when tracing children
 - Make `--forward` default signal behaviour
 - Fix follow-exec aliasing for config file
+- Fix `force_clean` merging to take into account the default being true
 
 ## [0.19.1] 2022-01-16
 ### Added

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -567,7 +567,9 @@ impl Config {
         self.all |= other.all;
         self.frozen |= other.frozen;
         self.locked |= other.locked;
-        self.force_clean |= other.force_clean;
+        // This is &= because force_clean true is the default. If one is false then that is
+        // non-default
+        self.force_clean &= other.force_clean;
         self.skip_clean |= other.skip_clean;
         self.ignore_tests |= other.ignore_tests;
         self.no_fail_fast |= other.no_fail_fast;


### PR DESCRIPTION
Merging of force-clean now means it's respected in tarpaulin.toml if set
to false

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
