### PR TITLE
Unify process handling for ptrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,6 @@ dependencies = [
  "libc",
  "memmap",
  "nix",
- "num_cpus",
  "object",
  "proc-macro2",
  "procfs",
@@ -582,16 +581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ humantime-serde = "1"
 indexmap = { version = "1.9.1", features = ["serde-1"] }
 lazy_static = "1.0"
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = {version = "0.2.25", default-features = false, features = ["env-filter", "fmt", "chrono", "ansi", "smallvec", "tracing-log"]}
+tracing-subscriber = { version = "0.2.25", default-features = false, features = ["env-filter", "fmt", "chrono", "ansi", "smallvec", "tracing-log"] }
 memmap = "0.7.0"
 object = "0.29"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
@@ -49,7 +49,7 @@ num_cpus = "1.13.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.94"
-nix = {version = "0.24.2", default-features = false, features = ["sched", "signal", "ptrace"]}
+nix = { version = "0.24.2", default-features = false, features = ["sched", "signal", "personality", "ptrace"] }
 procfs = "0.14"
 
 [features]

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -82,20 +82,20 @@ impl TestBinary {
         self.ty
     }
 
-    pub fn manifest_dir(&self) -> &Option<PathBuf> {
-        &self.cargo_dir
+    pub fn manifest_dir(&self) -> Option<&PathBuf> {
+        self.cargo_dir.as_ref()
     }
 
-    pub fn pkg_name(&self) -> &Option<String> {
-        &self.pkg_name
+    pub fn pkg_name(&self) -> Option<&str> {
+        self.pkg_name.as_deref()
     }
 
-    pub fn pkg_version(&self) -> &Option<String> {
-        &self.pkg_version
+    pub fn pkg_version(&self) -> Option<&str> {
+        self.pkg_version.as_deref()
     }
 
-    pub fn pkg_authors(&self) -> &Option<Vec<String>> {
-        &self.pkg_authors
+    pub fn pkg_authors(&self) -> Option<&[String]> {
+        self.pkg_authors.as_deref()
     }
 
     pub fn has_linker_paths(&self) -> bool {

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -94,7 +94,7 @@ impl TraceEvent {
         match wait {
             WaitStatus::Exited(_, i) => {
                 event.description = "Exited".to_string();
-                event.return_val = Some((i).into());
+                event.return_val = Some(i.into());
             }
             WaitStatus::Signaled(_, sig, _) => {
                 event.signal = Some(sig.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,21 +218,17 @@ pub fn launch_tarpaulin(
             if exe.should_panic() {
                 info!("Running a test executable that is expected to panic");
             }
-            let coverage = get_test_coverage(exe, &project_analysis, config, false, logger)?;
-            if let Some(res) = coverage {
-                result.merge(&res.0);
-                return_code |= if exe.should_panic() {
-                    (res.1 == 0).into()
-                } else {
-                    res.1
-                };
-            }
+            let (trace_map, run_result) = get_test_coverage(exe, &project_analysis, config, false, logger)?;
+            result.merge(&trace_map);
+            return_code |= if exe.should_panic() {
+                (run_result == 0).into()
+            } else {
+                run_result
+            };
             if config.run_ignored {
-                let coverage = get_test_coverage(exe, &project_analysis, config, true, logger)?;
-                if let Some(res) = coverage {
-                    result.merge(&res.0);
-                    return_code |= res.1;
-                }
+                let (trace_map, run_result) = get_test_coverage(exe, &project_analysis, config, true, logger)?;
+                result.merge(&trace_map);
+                return_code |= run_result;
             }
         }
         result.dedup();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,8 @@ pub fn launch_tarpaulin(
             if exe.should_panic() {
                 info!("Running a test executable that is expected to panic");
             }
-            let (trace_map, run_result) = get_test_coverage(exe, &project_analysis, config, false, logger)?;
+            let (trace_map, run_result) =
+                get_test_coverage(exe, &project_analysis, config, false, logger)?;
             result.merge(&trace_map);
             return_code |= if exe.should_panic() {
                 (run_result == 0).into()
@@ -226,7 +227,8 @@ pub fn launch_tarpaulin(
                 run_result
             };
             if config.run_ignored {
-                let (trace_map, run_result) = get_test_coverage(exe, &project_analysis, config, true, logger)?;
+                let (trace_map, run_result) =
+                    get_test_coverage(exe, &project_analysis, config, true, logger)?;
                 result.merge(&trace_map);
                 return_code |= run_result;
             }

--- a/src/process_handling/breakpoint.rs
+++ b/src/process_handling/breakpoint.rs
@@ -79,10 +79,7 @@ impl Breakpoint {
         pid: Pid,
         reenable: bool,
     ) -> Result<(bool, TracerAction<ProcessInfo>)> {
-        let is_running = match self.is_running.get(&pid) {
-            Some(r) => *r,
-            None => true,
-        };
+        let is_running = self.is_running.get(&pid).copied().unwrap_or(true);
         if is_running {
             let _ = self.enable(pid);
             self.step(pid)?;

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -1,48 +1,5 @@
-use crate::config::types::Mode;
-use crate::errors::RunError;
-use crate::process_handling::execute_test;
-use crate::{Config, TestBinary, TestHandle};
 use nix::sys::personality;
 use nix::{sched, unistd};
-
-/// Returns the coverage statistics for a test executable in the given workspace
-pub fn get_test_coverage(
-    test: &TestBinary,
-    config: &Config,
-    ignored: bool,
-) -> Result<Option<TestHandle>, RunError> {
-    if !test.path().exists() {
-        tracing::warn!("Test at {} doesn't exist", test.path().display());
-        return Ok(None);
-    }
-
-    // Solves CI issue when fixing #953 and #966 in PR #962
-    let threads = if config.follow_exec { 1 } else { sched::CpuSet::count() };
-
-    if let Err(e) = limit_affinity() {
-        tracing::warn!("Failed to set processor affinity {}", e);
-    }
-
-    unsafe {
-        match unistd::fork() {
-            Ok(unistd::ForkResult::Parent { child }) => Ok(Some(TestHandle::Id(child))),
-            Ok(unistd::ForkResult::Child) => {
-                let bin_type = match config.command {
-                    Mode::Test => "test",
-                    Mode::Build => "binary",
-                };
-                tracing::info!("Launching {}", bin_type);
-                execute_test(test, ignored, config, Some(threads))?;
-                Ok(None)
-            }
-            Err(err) => Err(RunError::TestCoverage(format!(
-                "Failed to run test {}, Error: {}",
-                test.path().display(),
-                err
-            ))),
-        }
-    }
-}
 
 pub fn disable_aslr() -> nix::Result<personality::Persona> {
     let this = personality::get()?;

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -1,9 +1,9 @@
 use nix::sys::personality;
 use nix::{sched, unistd};
 
-pub fn disable_aslr() -> nix::Result<personality::Persona> {
+pub fn disable_aslr() -> nix::Result<()> {
     let this = personality::get()?;
-    nix::sys::personality::set(this | personality::Persona::ADDR_NO_RANDOMIZE)
+    nix::sys::personality::set(this | personality::Persona::ADDR_NO_RANDOMIZE).map(|_| ())
 }
 
 pub fn limit_affinity() -> nix::Result<()> {

--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -82,10 +82,14 @@ fn launch_test(
         #[cfg(target_os = "linux")]
         TraceEngine::Ptrace => {
             // Solves CI issue when fixing #953 and #966 in PR #962
-            let threads = if config.follow_exec { 1 } else { nix::sched::CpuSet::count() };
+            let threads = if config.follow_exec {
+                1
+            } else {
+                nix::sched::CpuSet::count()
+            };
             let res = execute_test(test, ignored, config, Some(threads))?;
             Ok(res)
-        },
+        }
         e => {
             error!(
                 "Tarpaulin cannot execute tests with {:?} on this platform",
@@ -175,7 +179,11 @@ fn execute_test(
     num_threads: Option<usize>,
 ) -> Result<TestHandle, RunError> {
     info!("running {}", test.path().display());
-    let _ = env::set_current_dir(test.manifest_dir().cloned().unwrap_or_else(|| config.root()));
+    let _ = env::set_current_dir(
+        test.manifest_dir()
+            .cloned()
+            .unwrap_or_else(|| config.root()),
+    );
 
     debug!("Current working dir: {:?}", env::current_dir());
 
@@ -233,20 +241,26 @@ fn execute_test(
             unsafe {
                 // NOTE: Idea from https://github.com/luser/spawn-ptrace.
                 child.pre_exec(|| {
-                    linux::limit_affinity().map_err(|e| std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("failed to limit process affinity: {}", e)
-                    ))?;
+                    linux::limit_affinity().map_err(|e| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("failed to limit process affinity: {}", e),
+                        )
+                    })?;
 
-                    linux::disable_aslr().map_err(|e| std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("ASLR disable failed: {}", e)
-                    ))?;
+                    linux::disable_aslr().map_err(|e| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("ASLR disable failed: {}", e),
+                        )
+                    })?;
 
-                    ptrace_control::request_trace().map_err(|e| std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("traceme() failed: {}", e)
-                    ))?;
+                    ptrace_control::request_trace().map_err(|e| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("traceme() failed: {}", e),
+                        )
+                    })?;
 
                     Ok(())
                 });

--- a/src/process_handling/ptrace_control.rs
+++ b/src/process_handling/ptrace_control.rs
@@ -1,6 +1,6 @@
 use nix::errno::Errno;
 use nix::libc::{c_long, c_void};
-use nix::sys::ptrace::*;
+use nix::sys::ptrace::{self, AddressType, Options, Request, RequestType};
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
 use nix::Result;
@@ -9,35 +9,34 @@ use std::ptr;
 const RIP: u8 = 128;
 
 pub fn trace_children(pid: Pid) -> Result<()> {
-    //TODO need to check support.
+    // TODO need to check support.
     let options: Options = Options::PTRACE_O_TRACESYSGOOD
         | Options::PTRACE_O_TRACEEXEC
         | Options::PTRACE_O_TRACEEXIT
         | Options::PTRACE_O_TRACECLONE
         | Options::PTRACE_O_TRACEFORK
         | Options::PTRACE_O_TRACEVFORK;
-    setoptions(pid, options)
+    ptrace::setoptions(pid, options)
 }
 
 pub fn detach_child(pid: Pid) -> Result<()> {
-    detach(pid, None)
+    ptrace::detach(pid, None)
 }
 
 pub fn continue_exec(pid: Pid, sig: Option<Signal>) -> Result<()> {
-    cont(pid, sig)
+    ptrace::cont(pid, sig)
 }
 
-#[allow(deprecated)]
 pub fn single_step(pid: Pid) -> Result<()> {
-    step(pid, None)
+    ptrace::step(pid, None)
 }
 
 pub fn read_address(pid: Pid, address: u64) -> Result<c_long> {
-    read(pid, address as AddressType)
+    ptrace::read(pid, address as AddressType)
 }
 
 pub fn write_to_address(pid: Pid, address: u64, data: i64) -> Result<()> {
-    unsafe { write(pid, address as AddressType, data as *mut c_void) }
+    unsafe { ptrace::write(pid, address as AddressType, data as *mut c_void) }
 }
 
 #[allow(deprecated)]
@@ -71,9 +70,9 @@ pub fn set_instruction_pointer(pid: Pid, pc: u64) -> Result<c_long> {
 }
 
 pub fn request_trace() -> Result<()> {
-    traceme()
+    ptrace::traceme()
 }
 
 pub fn get_event_data(pid: Pid) -> Result<c_long> {
-    getevent(pid)
+    ptrace::getevent(pid)
 }

--- a/src/process_handling/ptrace_control.rs
+++ b/src/process_handling/ptrace_control.rs
@@ -6,6 +6,11 @@ use nix::unistd::Pid;
 use nix::Result;
 use std::ptr;
 
+#[cfg(target_arch = "x86_64")]
+const PC_INDEX: usize = libc::RIP as usize;
+#[cfg(target_arch = "x86")]
+const PC_INDEX: usize = libc::EIP as usize;
+
 pub fn trace_children(pid: Pid) -> Result<()> {
     // TODO need to check support.
     let options: Options = Options::PTRACE_O_TRACESYSGOOD
@@ -43,7 +48,7 @@ pub fn current_instruction_pointer(pid: Pid) -> Result<c_long> {
         libc::ptrace(
             Request::PTRACE_PEEKUSER as RequestType,
             pid.as_raw(),
-            (libc::RIP as usize * std::mem::size_of::<usize>()) as *mut c_void,
+            (PC_INDEX * std::mem::size_of::<usize>()) as *mut c_void,
             ptr::null_mut::<c_void>(),
         )
     };
@@ -57,7 +62,7 @@ pub fn set_instruction_pointer(pid: Pid, pc: u64) -> Result<()> {
         libc::ptrace(
             Request::PTRACE_POKEUSER as _,
             pid.as_raw(),
-            (libc::RIP as usize * std::mem::size_of::<usize>()) as *mut c_void,
+            (PC_INDEX * std::mem::size_of::<usize>()) as *mut c_void,
             pc as *mut c_void,
         )
     };

--- a/src/report/safe_json.rs
+++ b/src/report/safe_json.rs
@@ -19,7 +19,8 @@ impl serde_json::ser::Formatter for SafeFormatter {
         let mut start = 0;
         for (index, match_str) in fragment.match_indices(&['<', '>', '&']) {
             debug_assert_eq!(match_str.as_bytes().len(), 1);
-            self.0.write_string_fragment(writer, &fragment[start..index])?;
+            self.0
+                .write_string_fragment(writer, &fragment[start..index])?;
             self.write_char_escape(writer, CharEscape::AsciiControl(fragment.as_bytes()[index]))?;
             start = index + 1;
         }

--- a/src/statemachine/instrumented.rs
+++ b/src/statemachine/instrumented.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 use crate::config::Config;
 use crate::errors::RunError;
-use crate::process_handling::RunningProcessHandle;
 use crate::source_analysis::LineAnalysis;
 use crate::statemachine::*;
 use crate::TestHandle;
@@ -19,32 +18,20 @@ pub fn create_state_machine<'a>(
     event_log: &'a Option<EventLog>,
 ) -> (TestState, LlvmInstrumentedData<'a>) {
     let handle = test.into();
-    if let TestHandle::Process(process) = handle {
-        let llvm = LlvmInstrumentedData {
-            process: Some(process),
-            event_log,
-            config,
-            traces,
-            analysis,
-        };
-        (TestState::start_state(), llvm)
-    } else {
-        error!("The llvm cov statemachine requires a process::Child");
-        let invalid = LlvmInstrumentedData {
-            process: None,
-            config,
-            event_log,
-            traces,
-            analysis,
-        };
-        (TestState::End(1), invalid)
-    }
+    let llvm = LlvmInstrumentedData {
+        process: Some(handle),
+        event_log,
+        config,
+        traces,
+        analysis,
+    };
+    (TestState::start_state(), llvm)
 }
 
 /// Handle to the process for an instrumented binary. This will simply
 pub struct LlvmInstrumentedData<'a> {
     /// Parent pid of the test
-    process: Option<RunningProcessHandle>,
+    process: Option<TestHandle>,
     /// Program config
     config: &'a Config,
     /// Optional event log to update as the test progresses

--- a/src/statemachine/linux.rs
+++ b/src/statemachine/linux.rs
@@ -714,12 +714,12 @@ impl<'a> LinuxData<'a> {
         let mut hits_to_increment = HashSet::new();
         if let Some(process) = self.get_traced_process_mut(current) {
             let visited = visited_pcs.entry(process.parent).or_default();
-            if let Ok(rip) = current_instruction_pointer(current) {
-                let rip = (rip - 1) as u64;
-                trace!("Hit address {:#08x}", rip);
-                if process.breakpoints.contains_key(&rip) {
-                    let bp = process.breakpoints.get_mut(&rip).unwrap();
-                    let updated = if visited.contains(&rip) {
+            if let Ok(pc) = current_instruction_pointer(current) {
+                let pc = (pc - 1) as u64;
+                trace!("Hit address {:#x}", pc);
+                if process.breakpoints.contains_key(&pc) {
+                    let bp = process.breakpoints.get_mut(&pc).unwrap();
+                    let updated = if visited.contains(&pc) {
                         let _ = bp.jump_to(current);
                         (true, TracerAction::Continue(current.into()))
                     } else {
@@ -733,7 +733,7 @@ impl<'a> LinuxData<'a> {
                         }
                     };
                     if updated.0 {
-                        hits_to_increment.insert(rip - process.offset);
+                        hits_to_increment.insert(pc - process.offset);
                     }
                     action = Some(updated.1);
                 }

--- a/src/statemachine/mod.rs
+++ b/src/statemachine/mod.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
     }
 }
 pub fn create_state_machine<'a>(
-    test: impl Into<TestHandle>,
+    test: TestHandle,
     traces: &'a mut TraceMap,
     source_analysis: &'a HashMap<PathBuf, LineAnalysis>,
     config: &'a Config,


### PR DESCRIPTION
The setup tasks in `process_handling::linux::execute` can be achieved for `std::process::Command` through `std::process::Command::pre_exec` (as demonstrated by https://github.com/luser/spawn-ptrace). This means that the `TestHandle::Id` handle is no longer necessary, as the ptraced child process can also now be made into a `RunningProcessHandle`.