### PR TITLE
Fix gitlab coverage report yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,8 +481,9 @@ Gitlab can [show coverage information] in the diff of a merge request. For that,
 job: ...
   artifacts:
     reports:
-      cobertura:
-        - cobertura.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: cobertura.xml
 ```
 
 and generate a `cobertura.xml` as described under [Pycobertura](#pycobertura).


### PR DESCRIPTION
The previous YAML didn't work. This replaces it with one that works in my project, and which was taken from the [show coverage information] link just below the change