### PR TITLE
Improve build error messages

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -273,7 +273,11 @@ fn run_cargo(
                 }
                 Ok(Message::CompilerMessage(m)) => match m.message.level {
                     DiagnosticLevel::Error | DiagnosticLevel::Ice => {
-                        let msg = format!("{}: {}", m.target.name, m.message.message);
+                        let msg = if let Some(rendered) = m.message.rendered {
+                            rendered
+                        } else {
+                            format!("{}: {}", m.target.name, m.message.message)
+                        };
                         error = Some(RunError::TestCompile(msg));
                         break;
                     }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -46,7 +46,7 @@ impl Display for RunError {
             Self::Cargo(e) => write!(f, "Cargo failed to run! Error: {}", e),
             Self::Packages(e) => write!(f, "Failed to resolve package in manifest! Error: {}", e),
             Self::TestLaunch(e) => write!(f, "Failed to launch test: {}", e),
-            Self::TestCompile(e) => write!(f, "Failed to compile tests! Error: {}", e),
+            Self::TestCompile(e) => write!(f, "Failed to compile tests!\n{}", e),
             Self::TestRuntime(e) => write!(f, "Failed to run tests: {}", e),
             Self::TestFailed => write!(f, "Test failed during run"),
             Self::Parse(e) => write!(f, "Error while parsing: {}", e),


### PR DESCRIPTION
This PR improves build error messages to make it easier to understand why tests are failing to build. This would greatly help users who get hard to debug build error messages, e.g. https://github.com/xd009642/tarpaulin/issues/517

Build error message before changes:
```
Aug 18 18:30:01.312 ERROR cargo_tarpaulin: Failed to compile tests! Error: rust_sample: mismatched types
Error: "Failed to compile tests! Error: rust_sample: mismatched types"
```

Build error message after changes:
```
Aug 18 18:45:43.885 ERROR cargo_tarpaulin: Failed to compile tests!
error[E0308]: mismatched types
 --> src/lib.rs:5:5
  |
1 | fn get_message(hello: bool) -> String {
  |                                ------ expected `String` because of return type
...
5 |     "Hello, world!"
  |     ^^^^^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
  |     |
  |     expected struct `String`, found `&str`


Error: "Failed to compile tests!\nerror[E0308]: mismatched types\n --> src/lib.rs:5:5\n  |\n1 | fn get_message(hello: bool) -> String {\n  |                                ------ expected `String` because of return type\n...\n5 |     \"Hello, world!\"\n  |     ^^^^^^^^^^^^^^^- help: try using a conversion method: `.to_string()`\n  |     |\n  |     expected struct `String`, found `&str`\n\n"
```

PS
The build error message is not colored, unlike when running `cargo test` :(