### PR TITLE
Add 2-decimal point display precision for the report coverage % delta

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -65,7 +65,7 @@ impl Display for RunError {
             Self::Json(e) => write!(f, "Failed to generate JSON report! Error: {}", e),
             Self::Internal => write!(f, "Tarpaulin experienced an internal error"),
             Self::BelowThreshold(a, e) => {
-                write!(f, "Coverage is below the failure threshold {}% < {}%", a, e)
+                write!(f, "Coverage is below the failure threshold {:.2}% < {:.2}%", a, e)
             }
             Self::Engine(s) => write!(f, "Engine error: {}", s),
         }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -65,7 +65,11 @@ impl Display for RunError {
             Self::Json(e) => write!(f, "Failed to generate JSON report! Error: {}", e),
             Self::Internal => write!(f, "Tarpaulin experienced an internal error"),
             Self::BelowThreshold(a, e) => {
-                write!(f, "Coverage is below the failure threshold {:.2}% < {:.2}%", a, e)
+                write!(
+                    f,
+                    "Coverage is below the failure threshold {:.2}% < {:.2}%",
+                    a, e
+                )
             }
             Self::Engine(s) => write!(f, "Engine error: {}", s),
         }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -189,7 +189,7 @@ fn print_summary(config: &Config, result: &TraceMap) {
     } else {
         let delta = percent - 100.0f64 * last.coverage_percentage();
         println!(
-            "|| \n{:.2}% coverage, {}/{} lines covered, {:+}% change in coverage",
+            "|| \n{:.2}% coverage, {}/{} lines covered, {:+.2}% change in coverage",
             percent,
             result.total_covered(),
             result.total_coverable(),


### PR DESCRIPTION
This PR just adds 2-decimal point precision to the display for the coverage % delta and one error `Display` impl that also displays percentages.