### PR TITLE
Add `rust-cache` to the CI workflow.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
       - "*"
   pull_request:
 
+env:
+  RUST_BACKTRACE: 1
+
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -26,20 +29,14 @@ jobs:
           toolchain: ${{ matrix.version }}
           override: true
           components: rustfmt
-      - name: clean
-        run: cargo clean
+      - name: cache
+        uses: Swatinem/rust-cache@v2
       - name: build
         run: cargo build
-        env:
-          RUST_BACKTRACE: 1
       - name: test
-        run: cargo test 
-        env:
-          RUST_BACKTRACE: 1
+        run: cargo test
       - name: ignored test
         run: cargo test -- --ignored || true
-        env:
-          RUST_BACKTRACE: 1
         if: matrix.version == 'nightly'
       - name: check formatting
         run: cargo fmt -- --check
@@ -59,12 +56,12 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
           override: true
+      - name: cache
+        uses: Swatinem/rust-cache@v2
       - name: build
         run: cargo build
       - name: test
         run: cargo test -- || true
-        env:
-          RUST_BACKTRACE: 1
   mac:
     runs-on: macos-latest
     strategy:
@@ -80,9 +77,9 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
           override: true
+      - name: cache
+        uses: Swatinem/rust-cache@v2
       - name: build
         run: cargo build
       - name: test
         run: cargo test -- || true
-        env:
-          RUST_BACKTRACE: 1


### PR DESCRIPTION
When submitting #1101, I noticed the CI took a long time.

On all of my projects, I use https://github.com/marketplace/actions/rust-cache, which caches the compiled dependencies so that only the final executable is rebuilt on every push/PR. This should significantly speed up successive CI runs. (less so for nightly builds because the cache is invalidated daily)

I noticed on the Linux job, there was a `cargo clean` step that wasn't done on Windows or Mac. Because that would defeat the point of caching compiled dependencies, I removed it.

I also noticed the `RUST_BACKTRACE` environment variable was set individually, and moved that to a global workflow-level environment variable, so it applies everywhere. If that was a mistake, and it was applied individually for a reason, I can move it back.