### PR TITLE
Extra `<a>` elements added to HTML report.

### DIFF
--- a/src/report/report_viewer.js
+++ b/src/report/report_viewer.js
@@ -184,7 +184,7 @@ function File({file, onClick}) {
         + (file.is_folder ? ' files-list__file_folder': ''),
       onClick: () => onClick(file),
     },
-    e('td', null, pathToString(file.path)),
+    e('td', null, e('a', null, pathToString(file.path))),
     e('td', null,
       file.covered + ' / ' + file.coverable +
       (coverage >= 0 ? ' (' + coverage.toFixed(2) + '%)' : ''),


### PR DESCRIPTION
This PR slightly improves generated HTML report by helping keyboard-only users to navigate within the report.
Tested on Chome and Firefox browsers and Vimium C and Vimium FF extensions respectively.

## Before

When browsing Tarpaulin HTML report in a Browser (I've tried Firefox and Chrome), a mouse has to be used to navigate in the report (mouse-click on files and folder table rows). This is probably fine for most of users, since I assume most people do actively use mouse all the time.
However, among SW developers, there is (maybe small, but arguably growing) group of keyboard-only users, whom
consider the need of grabbing a mouse and making that mouse-clicks an unnecessary distraction in the workflow.

One way to retain a keyboard-only navigation in web pages is to extensions like Vimium. They rely on websites having a linked pages, and navigation based on `<a>....</a>` elements in the DOM.

This is something a Tarpaulin generated HTML report does now have (with an exception for the "Back" link).

Here is a picture showing how a link-based navigation looks when browsing the report using Vimium extension. Only the "Back" link is detected as a clickable element . To go further into the details of `examples` or `src` subdirs, one has to physically grab a mouse and do the left-mouse-click on them.

![tarpaulin-links-before](https://user-images.githubusercontent.com/1964880/197334831-74160aea-21dd-4648-be8d-87f914a62f18.png)

## After

Adding `<a></a>` wrapping elements so that browser extensions that allow to navigate in HTML pages can detect those and propose navigating actions.

Here is a picture of a modified tarpaulin HTML report with the newly added `<a>` elements to it. The Vimium extension detects these elements now and offers keyboard shortcuts to access them (overlays 'D' and 'J' in this case):

![tarpaulin-links](https://user-images.githubusercontent.com/1964880/197334554-c3c0d495-ce04-462e-be12-090f2f65bad8.png)

This change is tiny and trivial, but it actually helps a lot when trying to keep a keyboard-only working mode with Rust development having Tarpaulin int he game.

The newly added `<a>` elements are empty and carry no semantics to it (neither `href` nor `name` are set), but since the HTML report is actually a small React app, and it's the JS that handles clicks anyway, this seem to work fine on browsers I've tested that. 

The new elements do not change layout and seem to be transparent for when browsing in a classic way (e.g. with mouse button clicks).