### PR TITLE
Fix release workflow broken by a1bfc4ff6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            target: ${{ matrix.target }}
+            override: true
       - name: build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release
       - name: archive
         run: |
           GIT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)


### PR DESCRIPTION
Tentatively fix https://github.com/xd009642/tarpaulin/actions/runs/3498060423/jobs/5858366657#step:3:134 where the musl toolchain is not found.