### PR TITLE
Fix binstall support: Specify that only x86_64 linux gnu is supported

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ rustc_version = "0.4"
 [dev-dependencies]
 rusty-fork = "0.3.0"
 
-[package.metadata.binstall]
+[package.metadata.binstall."x86_64-unknown-linux-gnu"]
 pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ version }-travis.tar.gz"
 bin-dir = "cargo-tarpaulin"
 pkg-fmt = "tgz"


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
