### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: universal-apple-darwin
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cargo-tarpaulin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: taiki-e/create-gh-release-action@v1.3.0
+      - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: CHANGELOG.md
         env:
@@ -20,7 +20,7 @@ jobs:
   crates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: publish package to crates
         run: |
           cargo package
@@ -31,9 +31,12 @@ jobs:
     needs:
       - create-release
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -41,16 +44,17 @@ jobs:
             os: windows-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: aarch64-pc-windows-msvc
-            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          bin: rust-sandbox
+          bin: cargo-tarpaulin
           target: ${{ matrix.target }}
+          features: vendored-openssl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rusty-fork = "0.3.0"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ target }.tar.gz"
-bin-dir = "cargo-tarpaulin"
+bin-dir = "cargo-tarpaulin{ binary-ext }"
 pkg-fmt = "tgz"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,10 @@ rustc_version = "0.4"
 [dev-dependencies]
 rusty-fork = "0.3.0"
 
-[package.metadata.binstall."x86_64-unknown-linux-gnu"]
-pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ version }-travis.tar.gz"
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ target }.tar.gz"
 bin-dir = "cargo-tarpaulin"
 pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use rustc_version::{version, version_meta, Channel};
+use std::env;
 
 fn main() {
     assert!(version().expect("Couldn't get compiler version").major >= 1);
@@ -10,6 +11,9 @@ fn main() {
         println!("cargo:rustc-cfg=nightly");
     }
 
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    println!("cargo:rustc-cfg=ptrace_supported");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+    if target_os == "linux" && target_arch == "x86_64" {
+        println!("cargo:rustc-cfg=ptrace_supported");
+    }
 }


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

As said in https://github.com/taiki-e/install-action/pull/42#issuecomment-1372184541, I would like to help improve release staff. (If work on this is in progress on your end and you do not need this patch, feel free to close this PR.)

This patch updates the release workflow and makes the release work on x86_64 linux-gnu/linux-musl/macos/windows and aarch64 linux-gnu/linux-musl/macos. The following are specific changes:

- Add x86_64/aarch64 linux-musl
  - Closes https://github.com/xd009642/tarpaulin/issues/1130
- Remove aarch64 windows.
  - ~~aarch64 linux fails to build [^1]: https://github.com/taiki-e/tarpaulin/actions/runs/3875026523/jobs/6606999714~~ EDIT: fixed in https://github.com/xd009642/tarpaulin/pull/1174/commits/5476833acd2cf994ebecba6949d29aeb74a857e7
  - aarch64 windows doesn't support profiler_builtins
- Enable vendored-openssl feature
  - At least on linux-musl we cannot build without it. [^1]
  - For now, I enabled this for all targets, but it is possible to control whether this is enabled or disabled per target.
- Use the latest taiki-e/create-gh-release-action and actions/checkout
- Update binstall metadata to match new archive names.

I tested this with a fork by temporarily disabling the configs around `cargo publish`; here is generated release: https://github.com/taiki-e/tarpaulin/releases/tag/0.23.1
I also confirmed that the binaries created in the above test pass install-action's CI in all environments: https://github.com/taiki-e/install-action/actions/runs/3875547860/jobs/6608244922

cc https://github.com/taiki-e/install-action/pull/42
fyi @thomcc @NobodyXu 

[^1]: [These targets are included in the test matrix in rust.yml](https://github.com/xd009642/tarpaulin/blob/5f5e566e173d34afe7919b480b40336c4aaf6537/.github/workflows/rust.yml#L21-L22), but the job is actually testing the host target instead of these targets because [the --target option is not passed to cargo](https://github.com/xd009642/tarpaulin/blob/5f5e566e173d34afe7919b480b40336c4aaf6537/.github/workflows/rust.yml#L33-L39).
