### PR TITLE
Save event log to report directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 From 2019 onwards, all notable changes to tarpaulin will be documented in this
 file.
 
+## [Unreleased]
+### Changed
+- Dumped traces are now saved to reports output directory
+
 ## [0.24.0] 2023-01-24
 ### Added
 - Merge rustdocflags field from `cargo/config.toml` with env tarpaulin sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ file.
 ## [Unreleased]
 ### Changed
 - Dumped traces are now saved to reports output directory
+- Change event log name to print datetime stamps without colons or slashes so they'll save in other
+operating systems
 
 ## [0.24.0] 2023-01-24
 ### Added

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -218,10 +218,7 @@ impl EventLog {
 
 impl Drop for EventLog {
     fn drop(&mut self) {
-        let fname = format!(
-            "tarpaulin_{}.json",
-            Local::now().to_rfc3339_opts(SecondsFormat::Secs, false)
-        );
+        let fname = format!("tarpaulin_{}.json", Local::now().format("%Y%m%d%H%M%S"));
         let path = self.output_folder.join(fname);
         info!("Serializing tarpaulin debug log to {}", path.display());
         if let Ok(output) = File::create(path) {

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -1,4 +1,5 @@
 use crate::cargo::TestBinary;
+use crate::config::Config;
 #[cfg(ptrace_supported)]
 use crate::ptrace_control::*;
 #[cfg(ptrace_supported)]
@@ -14,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
 use tracing::{info, warn};
 
@@ -165,14 +166,17 @@ pub struct EventLog {
     #[serde(skip)]
     start: Option<Instant>,
     manifest_paths: HashSet<PathBuf>,
+    #[serde(skip)]
+    output_folder: PathBuf,
 }
 
 impl EventLog {
-    pub fn new(manifest_paths: HashSet<PathBuf>) -> Self {
+    pub fn new(manifest_paths: HashSet<PathBuf>, config: &Config) -> Self {
         Self {
             events: RefCell::new(vec![]),
             start: Some(Instant::now()),
             manifest_paths,
+            output_folder: config.output_dir(),
         }
     }
 
@@ -218,7 +222,7 @@ impl Drop for EventLog {
             "tarpaulin_{}.json",
             Local::now().to_rfc3339_opts(SecondsFormat::Secs, false)
         );
-        let path = Path::new(&fname);
+        let path = self.output_folder.join(fname);
         info!("Serializing tarpaulin debug log to {}", path.display());
         if let Ok(output) = File::create(path) {
             if let Err(e) = serde_json::to_writer(output, self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,16 @@ pub fn trace(configs: &[Config]) -> Result<TraceMap, RunError> {
 
 fn create_logger(configs: &[Config]) -> Option<EventLog> {
     if configs.iter().any(|c| c.dump_traces) {
-        Some(EventLog::new(configs.iter().map(|x| x.root()).collect()))
+        let config = if let Some(c) = configs.iter().find(|c| c.output_directory.is_some()) {
+            c
+        } else {
+            &configs[0]
+        };
+
+        Some(EventLog::new(
+            configs.iter().map(|x| x.root()).collect(),
+            config,
+        ))
     } else {
         None
     }


### PR DESCRIPTION
This keeps things somewhat consistent as it's a report and makes it easier for people to keep project root clean of extraneous files

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
