### PR TITLE
Fixes #1183

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ file.
 - Dumped traces are now saved to reports output directory
 - Change event log name to print datetime stamps without colons or slashes so they'll save in other
 operating systems
+- Set `LLVM_PROFILE_FILE` for building tests and delete the generated profraws to ignore build script
+coverage 
 
 ## [0.24.0] 2023-01-24
 ### Added

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -6,7 +6,7 @@ use crate::ptrace_control::*;
 use crate::statemachine::ProcessInfo;
 use crate::statemachine::TracerAction;
 use crate::traces::{Location, TraceMap};
-use chrono::{offset::Local, SecondsFormat};
+use chrono::offset::Local;
 #[cfg(ptrace_supported)]
 use nix::libc::*;
 #[cfg(ptrace_supported)]

--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -17,6 +17,7 @@ pub enum TestHandle {
     Process(RunningProcessHandle),
 }
 
+#[derive(Debug)]
 pub struct RunningProcessHandle {
     /// Used to map coverage counters to line numbers
     pub(crate) path: PathBuf,


### PR DESCRIPTION
`-C instrument-code` causes build scripts to generate profraw files in the root directory. This also means for every build script executed you get another profraw. I fix this by moving to a profraw file name that will clash resulting in only one file and then deleting it after the tests are built.

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
