### PR TITLE
Clippy: Improve readablility when formatting strings.

### DIFF
--- a/src/branching/mod.rs
+++ b/src/branching/mod.rs
@@ -201,8 +201,8 @@ mod tests {
         let source = "fn foo(x: i32) {
             if x > 0 {
                 println!(\"BOO\");
-            } 
-            else 
+            }
+            else
             {
                 todo!()
             }
@@ -234,9 +234,9 @@ mod tests {
                 println!(\"BOO\");
             } else if x < 0 {
                 todo!()
-            } 
-            else 
-            {   
+            }
+            else
+            {
                 todo!()
             }
         }";
@@ -254,7 +254,7 @@ mod tests {
             }
         }
         let branches = branches.unwrap();
-        println!("Branches: {:?}", branches);
+        println!("Branches: {branches:?}");
         assert!(!branches.implicit_default);
         assert_eq!(branches.ranges.len(), 3);
         assert_eq!(branches.ranges[0], LineRange::new(2, 4));

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -222,7 +222,7 @@ pub fn get_tests(config: &Config) -> Result<CargoOutput, RunError> {
         info!("Cleaning project");
         if cleanup_dir.exists() {
             if let Err(e) = remove_dir_all(cleanup_dir) {
-                error!("Cargo clean failed: {}", e);
+                error!("Cargo clean failed: {e}");
             }
         }
     }
@@ -321,7 +321,7 @@ fn run_cargo(
                     }
                 }
                 Err(e) => {
-                    error!("Error parsing cargo messages {}", e);
+                    error!("Error parsing cargo messages {e}");
                 }
                 _ => {}
             }
@@ -525,14 +525,14 @@ fn create_command(manifest_path: &str, config: &Config, ty: Option<RunType>) -> 
             .ok()
             .filter(|t| t.starts_with("nightly") || bootstrap)
         {
-            test_cmd.args(&[format!("+{}", toolchain).as_str()]);
+            test_cmd.args(&[format!("+{toolchain}").as_str()]);
         } else if !bootstrap && override_toolchain {
             test_cmd.args(&["+nightly"]);
         }
         test_cmd.args(&["test"]);
     } else {
         if let Ok(toolchain) = env::var("RUSTUP_TOOLCHAIN") {
-            test_cmd.arg(format!("+{}", toolchain));
+            test_cmd.arg(format!("+{toolchain}"));
         }
         if config.command == Mode::Test {
             test_cmd.args(&["test", "--no-run"]);
@@ -638,7 +638,7 @@ fn init_args(test_cmd: &mut Command, config: &Config) {
         test_cmd.arg("--offline");
     }
     for feat in &config.unstable_features {
-        test_cmd.arg(format!("-Z{}", feat));
+        test_cmd.arg(format!("-Z{feat}"));
     }
     if config.command == Mode::Test && !config.varargs.is_empty() {
         let mut args = vec!["--".to_string()];

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -585,7 +585,7 @@ impl Config {
     pub fn parse_config_toml(buffer: &[u8]) -> std::io::Result<Vec<Self>> {
         let mut map: IndexMap<String, Self> = toml::from_slice(buffer).map_err(|e| {
             error!("Invalid config file {}", e);
-            Error::new(ErrorKind::InvalidData, format!("{}", e))
+            Error::new(ErrorKind::InvalidData, format!("{e}"))
         })?;
 
         let mut result = Vec::new();
@@ -670,7 +670,7 @@ impl Config {
         }
 
         let new_flags = match (self.rustflags.as_ref(), other.rustflags.as_ref()) {
-            (Some(a), Some(b)) => Some(format!("{} {}", a, b)),
+            (Some(a), Some(b)) => Some(format!("{a} {b}")),
             (Some(a), None) => Some(a.clone()),
             (None, Some(b)) => Some(b.clone()),
             _ => None,
@@ -1016,8 +1016,8 @@ mod tests {
                 let root_base = "";
             }
         }
-        let path_a = PathBuf::from(format!("{}/this/should/form/a/rel/path/", root_base));
-        let path_b = PathBuf::from(format!("{}/this/should/form/b/rel/path/", root_base));
+        let path_a = PathBuf::from(format!("{root_base}/this/should/form/a/rel/path/"));
+        let path_b = PathBuf::from(format!("{root_base}/this/should/form/b/rel/path/"));
 
         let rel_path = path_relative_from(&path_b, &path_a);
         assert!(rel_path.is_some());
@@ -1027,7 +1027,7 @@ mod tests {
             "Wrong relative path"
         );
 
-        let path_a = PathBuf::from(format!("{}/this/should/not/form/a/rel/path/", root_base));
+        let path_a = PathBuf::from(format!("{root_base}/this/should/not/form/a/rel/path/"));
         let path_b = Path::new("this/should/not/form/a/rel/path/");
         assert!(!path_b.is_absolute());
         assert!(path_a.is_absolute());
@@ -1205,7 +1205,7 @@ mod tests {
 
                 [no_dir]
                 coveralls = "xyz"
-                
+
                 [other_dir]
                 output-dir = "C:/bar"
                 "#;
@@ -1217,7 +1217,7 @@ mod tests {
 
                 [no_dir]
                 coveralls = "xyz"
-                
+
                 [other_dir]
                 output-dir = "/bar"
                 "#;
@@ -1261,7 +1261,7 @@ mod tests {
         let toml = r#"
         [flag1]
         rustflags = "xyz"
-        
+
         [flag2]
         rustflags = "bar"
         "#;

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -42,36 +42,35 @@ pub enum RunError {
 impl Display for RunError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::Manifest(e) => write!(f, "Failed to parse Cargo.toml! Error: {}", e),
-            Self::Cargo(e) => write!(f, "Cargo failed to run! Error: {}", e),
-            Self::Packages(e) => write!(f, "Failed to resolve package in manifest! Error: {}", e),
-            Self::TestLaunch(e) => write!(f, "Failed to launch test: {}", e),
-            Self::TestCompile(e) => write!(f, "Failed to compile tests!\n{}", e),
-            Self::TestRuntime(e) => write!(f, "Failed to run tests: {}", e),
+            Self::Manifest(e) => write!(f, "Failed to parse Cargo.toml! Error: {e}"),
+            Self::Cargo(e) => write!(f, "Cargo failed to run! Error: {e}"),
+            Self::Packages(e) => write!(f, "Failed to resolve package in manifest! Error: {e}"),
+            Self::TestLaunch(e) => write!(f, "Failed to launch test: {e}"),
+            Self::TestCompile(e) => write!(f, "Failed to compile tests!\n{e}"),
+            Self::TestRuntime(e) => write!(f, "Failed to run tests: {e}"),
             Self::TestFailed => write!(f, "Test failed during run"),
-            Self::Parse(e) => write!(f, "Error while parsing: {}", e),
-            Self::TestCoverage(e) => write!(f, "Failed to get test coverage! Error: {}", e),
+            Self::Parse(e) => write!(f, "Error while parsing: {e}"),
+            Self::TestCoverage(e) => write!(f, "Failed to get test coverage! Error: {e}"),
             // TODO: Better error message!
-            Self::Trace(e) => write!(f, "Failed to trace! Error: {}", e),
-            Self::CovReport(e) => write!(f, "Failed to report coverage! Error: {}", e),
-            Self::OutFormat(e) => write!(f, "{}", e),
-            Self::IO(e) => write!(f, "{}", e),
-            Self::StateMachine(e) => write!(f, "Error running test: {}", e),
+            Self::Trace(e) => write!(f, "Failed to trace! Error: {e}"),
+            Self::CovReport(e) => write!(f, "Failed to report coverage! Error: {e}"),
+            Self::OutFormat(e) => write!(f, "{e}"),
+            Self::IO(e) => write!(f, "{e}"),
+            Self::StateMachine(e) => write!(f, "Error running test: {e}"),
             #[cfg(ptrace_supported)]
-            Self::NixError(e) => write!(f, "{}", e),
-            Self::Html(e) => write!(f, "Failed to generate HTML report! Error: {}", e),
-            Self::XML(e) => write!(f, "Failed to generate XML report! Error: {}", e),
-            Self::Lcov(e) => write!(f, "Failed to generate Lcov report! Error: {}", e),
-            Self::Json(e) => write!(f, "Failed to generate JSON report! Error: {}", e),
+            Self::NixError(e) => write!(f, "{e}"),
+            Self::Html(e) => write!(f, "Failed to generate HTML report! Error: {e}"),
+            Self::XML(e) => write!(f, "Failed to generate XML report! Error: {e}"),
+            Self::Lcov(e) => write!(f, "Failed to generate Lcov report! Error: {e}"),
+            Self::Json(e) => write!(f, "Failed to generate JSON report! Error: {e}"),
             Self::Internal => write!(f, "Tarpaulin experienced an internal error"),
             Self::BelowThreshold(a, e) => {
                 write!(
                     f,
-                    "Coverage is below the failure threshold {:.2}% < {:.2}%",
-                    a, e
+                    "Coverage is below the failure threshold {a:.2}% < {e:.2}%"
                 )
             }
-            Self::Engine(s) => write!(f, "Engine error: {}", s),
+            Self::Engine(s) => write!(f, "Engine error: {s}"),
         }
     }
 }

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -223,7 +223,7 @@ impl Drop for EventLog {
         info!("Serializing tarpaulin debug log to {}", path.display());
         if let Ok(output) = File::create(path) {
             if let Err(e) = serde_json::to_writer(output, self) {
-                warn!("Failed to serialise or write result: {}", e);
+                warn!("Failed to serialise or write result: {e}");
             }
         } else {
             warn!("Failed to create log file");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn setup_logging(color: Color, debug: bool, verbose: bool) {
             for s in env.split(',') {
                 match s.parse() {
                     Ok(d) => filter = filter.add_directive(d),
-                    Err(err) => println!("WARN ignoring log directive: `{}`: {}", s, err),
+                    Err(err) => println!("WARN ignoring log directive: `{s}`: {err}"),
                 };
             }
             filter
@@ -70,7 +70,7 @@ pub fn setup_logging(color: Color, debug: bool, verbose: bool) {
         .try_init();
 
     if let Err(e) = res {
-        eprintln!("Logging may be misconfigured: {}", e);
+        eprintln!("Logging may be misconfigured: {e}");
     }
 
     debug!("set up logging");
@@ -104,7 +104,7 @@ pub fn trace(configs: &[Config]) -> Result<TraceMap, RunError> {
                 tracemap.merge(&t);
             }
             Err(e) => {
-                error!("{}", e);
+                error!("{e}");
                 tarpaulin_result = tarpaulin_result.and(Err(e));
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,14 +21,14 @@ fn print_env(seen_rustflags: HashMap<String, Vec<String>>, prefix: &str, default
     info!("Printing `{}`", prefix);
     if seen_rustflags.is_empty() {
         info!("No configs provided printing default RUSTFLAGS");
-        println!("{}={}", prefix, default_val);
+        println!("{prefix}={default_val}");
     } else if seen_rustflags.len() == 1 {
         let flags = seen_rustflags.keys().next().unwrap();
-        println!(r#"{}="{}""#, prefix, flags);
+        println!(r#"{prefix}="{flags}""#);
     } else {
         for (k, v) in &seen_rustflags {
             info!("RUSTFLAGS for configs {:?}", v);
-            println!(r#"{}="{}""#, prefix, k);
+            println!(r#"{prefix}="{k}""#);
         }
     }
 }

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -84,13 +84,13 @@ pub fn execute(
     envar: &[(String, String)],
 ) -> Result<TestHandle, RunError> {
     let program = CString::new(test.display().to_string()).unwrap_or_default();
-    disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {}", e)))?;
+    disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {e}")))?;
 
     request_trace().map_err(|e| RunError::Trace(e.to_string()))?;
 
     let envar = envar
         .iter()
-        .map(|(k, v)| CString::new(format!("{}={}", k, v).as_str()).unwrap_or_default())
+        .map(|(k, v)| CString::new(format!("{k}={v}").as_str()).unwrap_or_default())
         .collect::<Vec<CString>>();
 
     let argv = argv

--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -56,7 +56,7 @@ impl RunningProcessHandle {
 impl fmt::Display for TestHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TestHandle::Id(id) => write!(f, "{}", id),
+            TestHandle::Id(id) => write!(f, "{id}"),
             TestHandle::Process(c) => write!(f, "{}", c.child.id()),
         }
     }
@@ -279,10 +279,7 @@ fn execute_test(
             debug!("Args: {:?}", argv);
             execute(test.path(), &argv, envars.as_slice())
         }
-        e => Err(RunError::Engine(format!(
-            "invalid execution engine {:?}",
-            e
-        ))),
+        e => Err(RunError::Engine(format!("invalid execution engine {e:?}"))),
     }
 }
 

--- a/src/report/cobertura.rs
+++ b/src/report/cobertura.rs
@@ -74,7 +74,7 @@ impl fmt::Display for Error {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::ExportError(ref e) => write!(f, "Export Error {}", e),
+            Error::ExportError(ref e) => write!(f, "Export Error {e}"),
             Error::Unknown => write!(f, "Unknown Error"),
         }
     }

--- a/src/report/coveralls.rs
+++ b/src/report/coveralls.rs
@@ -21,11 +21,11 @@ fn get_git_info(manifest_path: &Path) -> Result<GitInfo, String> {
 
     let head = repo
         .head()
-        .map_err(|err| format!("failed to get repository head: {}", err))?;
+        .map_err(|err| format!("failed to get repository head: {err}"))?;
     let branch = git2::Branch::wrap(head);
     let branch_name = branch
         .name()
-        .map_err(|err| format!("failed to get branch name: {}", err))?;
+        .map_err(|err| format!("failed to get branch name: {err}"))?;
     let get_string = |data: Option<&str>| match data {
         Some(str) => Ok(str.to_string()),
         None => Err("string is not valid utf-8".to_string()),
@@ -35,7 +35,7 @@ fn get_git_info(manifest_path: &Path) -> Result<GitInfo, String> {
         .head()
         .unwrap()
         .peel_to_commit()
-        .map_err(|err| format!("failed to get commit: {}", err))?;
+        .map_err(|err| format!("failed to get commit: {err}"))?;
 
     let author = commit.author();
     let committer = commit.committer();
@@ -134,7 +134,7 @@ pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError>
                 trace!("Coveralls response {:?}", s);
                 Ok(())
             }
-            Err(e) => Err(RunError::CovReport(format!("Coveralls send failed. {}", e))),
+            Err(e) => Err(RunError::CovReport(format!("Coveralls send failed. {e}"))),
         }
     } else {
         Err(RunError::CovReport(

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -39,8 +39,7 @@ fn get_json(coverage_data: &TraceMap, context: Context) -> Result<String, RunErr
                 }
 
                 return Err(RunError::Html(format!(
-                    "Unable to read source file to string: {}",
-                    e
+                    "Unable to read source file to string: {e}"
                 )));
             }
         };
@@ -58,14 +57,14 @@ fn get_json(coverage_data: &TraceMap, context: Context) -> Result<String, RunErr
     }
 
     safe_json::to_string_safe(&report)
-        .map_err(|e| RunError::Html(format!("Report isn't serializable: {}", e)))
+        .map_err(|e| RunError::Html(format!("Report isn't serializable: {e}")))
 }
 
 pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError> {
     let file_path = config.output_dir().join("tarpaulin-report.html");
     let mut file = match File::create(file_path) {
         Ok(k) => k,
-        Err(e) => return Err(RunError::Html(format!("File is not writeable: {}", e))),
+        Err(e) => return Err(RunError::Html(format!("File is not writeable: {e}"))),
     };
 
     let report_json = get_json(coverage_data, Context::CurrentResults)?;

--- a/src/report/lcov.rs
+++ b/src/report/lcov.rs
@@ -8,7 +8,7 @@ pub fn export(coverage_data: &TraceMap, config: &Config) -> Result<(), RunError>
     let file_path = config.output_dir().join("lcov.info");
     let file = match File::create(file_path) {
         Ok(k) => k,
-        Err(e) => return Err(RunError::Lcov(format!("File is not writeable: {}", e))),
+        Err(e) => return Err(RunError::Lcov(format!("File is not writeable: {e}"))),
     };
 
     write_lcov(file, coverage_data)
@@ -39,7 +39,7 @@ fn write_lcov(mut file: impl Write, coverage_data: &TraceMap) -> Result<(), RunE
                 };
 
                 fns.push(format!("FN:{},{}", trace.line, fn_name));
-                fnda.push(format!("FNDA:{},{}", fn_hits, fn_name));
+                fnda.push(format!("FNDA:{fn_hits},{fn_name}"));
             }
 
             if let CoverageStat::Line(hits) = trace.stats {
@@ -48,17 +48,17 @@ fn write_lcov(mut file: impl Write, coverage_data: &TraceMap) -> Result<(), RunE
         }
 
         for fn_line in &fns {
-            writeln!(file, "{}", fn_line)?;
+            writeln!(file, "{fn_line}",)?;
         }
 
         writeln!(file, "FNF:{}", fns.len())?;
 
         for fnda_line in fnda {
-            writeln!(file, "{}", fnda_line)?;
+            writeln!(file, "{fnda_line}")?;
         }
 
         for (line, hits) in &da {
-            writeln!(file, "DA:{},{}", line, hits)?;
+            writeln!(file, "DA:{line},{hits}")?;
         }
 
         writeln!(file, "LF:{}", da.len())?;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -209,10 +209,10 @@ fn accumulate_lines(
         } else {
             match (group.first(), group.last()) {
                 (Some(first), Some(last)) if first == last => {
-                    acc.push(format!("{}", first));
+                    acc.push(format!("{first}"));
                 }
                 (Some(first), Some(last)) => {
-                    acc.push(format!("{}-{}", first, last));
+                    acc.push(format!("{first}-{last}"));
                 }
                 (Some(_), None) | (None, _) => (),
             };

--- a/src/statemachine/linux.rs
+++ b/src/statemachine/linux.rs
@@ -145,8 +145,7 @@ impl<'a> StateData for LinuxData<'a> {
                 "Unexpected signal when starting test".to_string(),
             )),
             Err(e) => Err(RunError::TestRuntime(format!(
-                "Error when starting test: {}",
-                e
+                "Error when starting test: {e}"
             ))),
         }
     }
@@ -213,8 +212,7 @@ impl<'a> StateData for LinuxData<'a> {
                 Err(e) => {
                     running = false;
                     result = Err(RunError::TestRuntime(format!(
-                        "An error occurred while waiting for response from test: {}",
-                        e
+                        "An error occurred while waiting for response from test: {e}"
                     )));
                 }
             }
@@ -254,8 +252,7 @@ impl<'a> StateData for LinuxData<'a> {
                 WaitStatus::PtraceEvent(c, s, e) => match self.handle_ptrace_event(*c, *s, *e) {
                     Ok(s) => Ok(s),
                     Err(e) => Err(RunError::TestRuntime(format!(
-                        "Error occurred when handling ptrace event: {}",
-                        e
+                        "Error occurred when handling ptrace event: {e}"
                     ))),
                 },
                 WaitStatus::Stopped(c, Signal::SIGTRAP) => {
@@ -263,8 +260,7 @@ impl<'a> StateData for LinuxData<'a> {
                     match self.collect_coverage_data(&mut pcs) {
                         Ok(s) => Ok(s),
                         Err(e) => Err(RunError::TestRuntime(format!(
-                            "Error when collecting coverage: {}",
-                            e
+                            "Error when collecting coverage: {e}"
                         ))),
                     }
                 }
@@ -279,8 +275,7 @@ impl<'a> StateData for LinuxData<'a> {
                     let pc = current_instruction_pointer(*child).unwrap_or(1) - 1;
                     trace!("SIGILL raised. Child program counter is: 0x{:x}", pc);
                     Err(RunError::TestRuntime(format!(
-                        "Error running test - SIGILL raised in {}",
-                        child
+                        "Error running test - SIGILL raised in {child}"
                     )))
                 }
                 WaitStatus::Stopped(c, Signal::SIGCHLD) => {
@@ -704,12 +699,11 @@ impl<'a> LinuxData<'a> {
                     ))
                 }
                 _ => Err(RunError::TestRuntime(format!(
-                    "Unrecognised ptrace event {}",
-                    event
+                    "Unrecognised ptrace event {event}"
                 ))),
             }
         } else {
-            trace!("Unexpected signal with ptrace event {}", event);
+            trace!("Unexpected signal with ptrace event {event}");
             trace!("Signal: {:?}", sig);
             Err(RunError::TestRuntime("Unexpected signal".to_string()))
         }

--- a/src/test_loader.rs
+++ b/src/test_loader.rs
@@ -226,7 +226,7 @@ fn get_line_addresses<'data: 'file, 'file>(
 ) -> Result<TraceMap> {
     let project = config.root();
     let io_err = |e| {
-        error!("IO error parsing section: {}", e);
+        error!("IO error parsing section: {e}");
         Error::Io
     };
     let mut result = TraceMap::new();

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -55,7 +55,7 @@ impl Add for CoverageStat {
 impl Display for CoverageStat {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match *self {
-            CoverageStat::Line(x) => write!(f, "hits: {}", x),
+            CoverageStat::Line(x) => write!(f, "hits: {x}"),
             _ => write!(f, ""),
         }
     }


### PR DESCRIPTION
When I run ```cargo clippy``` the output is so large that it is difficult to reason with 

So I have cherry picked a single frequently repeated  warning to make the review process simpler, and to make the list more manageable.

All the changes are of the form 

```rust
-    acc.push(format!("{}-{}", first, last));
+    acc.push(format!("{first}-{last}"));
```