### PR TITLE
Clippy: Simplify iter_cloned_collect

### DIFF
--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -268,7 +268,7 @@ fn execute_test(
             debug!("Args: {:?}", argv);
             let mut child = Command::new(test.path());
             child.envs(envars).args(&argv);
-            let others = other_binaries.iter().cloned().collect();
+            let others = other_binaries.to_vec();
             let hnd = RunningProcessHandle::new(test, others, &mut child, config)?;
             Ok(hnd.into())
         }


### PR DESCRIPTION
Clippy has spotted a .clone() call which can be removed.

[iter_cloned_collect](https://rust-lang.github.io/rust-clippy/master/index.html#iter_cloned_collect)
