### PR TITLE
More fixes for supplementary objects

### DIFF
--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -4,8 +4,12 @@ use crate::config::Config;
 use crate::ptrace_control::*;
 #[cfg(ptrace_supported)]
 use crate::statemachine::ProcessInfo;
+#[cfg(ptrace_supported)]
 use crate::statemachine::TracerAction;
-use crate::traces::{Location, TraceMap};
+#[cfg(ptrace_supported)]
+use crate::traces::TraceMap;
+
+use crate::traces::Location;
 use chrono::offset::Local;
 #[cfg(ptrace_supported)]
 use nix::libc::*;

--- a/src/statemachine/instrumented.rs
+++ b/src/statemachine/instrumented.rs
@@ -114,8 +114,26 @@ impl<'a> StateData for LlvmInstrumentedData<'a> {
                         let code = exit.code().unwrap_or(1);
                         return Ok(Some(TestState::End(code)));
                     }
-                    // Panics due to a todo!();
-                    let mut binaries = parent.extra_binaries.clone();
+
+                    let mut binaries = parent
+                        .extra_binaries
+                        .iter()
+                        .filter(|path| {
+                            // extra binaries might not exist yet and be created
+                            // later by the test suite
+                            if path.exists() {
+                                true
+                            } else {
+                                info!(
+                                    "Skipping additional object '{}' since the file does not exist",
+                                    path.display()
+                                );
+                                false
+                            }
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+
                     binaries.push(binary_path);
                     info!("Mapping coverage data to source");
                     let mapping =


### PR DESCRIPTION
Note: this PR targets the `fix/canonicalise-object` branch, not `develop`.

I need one other change to fully fix #1156 for me: the supplementary objects are only created in the middle of the test suite, so trying to access it before results in "file not found". I think the simplest solution is to check if the file exists before trying to parse it, informing the user if the file is skipped so that typos can be corrected.
