### PR TITLE
Simplify cargo version parsing

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -31,9 +31,6 @@ struct CargoVersionInfo {
     major: usize,
     minor: usize,
     channel: Channel,
-    year: usize,
-    month: usize,
-    day: usize,
 }
 
 impl CargoVersionInfo {
@@ -174,7 +171,7 @@ impl DocTestBinaryMeta {
 lazy_static! {
     static ref CARGO_VERSION_INFO: Option<CargoVersionInfo> = {
         let version_info = Regex::new(
-            r"cargo (\d)\.(\d+)\.\d+([\-betanightly]*)(\.[[:alnum:]]+)? \([[:alnum:]]+ (\d{4})-(\d{2})-(\d{2})\)",
+            r"cargo (\d)\.(\d+)\.\d+([\-betanightly]*)(\.[[:alnum:]]+)?",
         )
         .unwrap();
         Command::new("cargo")
@@ -192,16 +189,10 @@ lazy_static! {
                         "-beta" => Channel::Beta,
                         _ => Channel::Stable,
                     };
-                    let year = cap[5].parse().unwrap();
-                    let month = cap[6].parse().unwrap();
-                    let day = cap[7].parse().unwrap();
                     Some(CargoVersionInfo {
                         major,
                         minor,
                         channel,
-                        year,
-                        month,
-                        day,
                     })
                 } else {
                     None
@@ -917,18 +908,12 @@ mod tests {
             major: 1,
             minor: 50,
             channel: Channel::Nightly,
-            year: 2020,
-            month: 12,
-            day: 22,
         };
         assert!(version.supports_llvm_cov());
         let version = CargoVersionInfo {
             major: 1,
             minor: 60,
             channel: Channel::Stable,
-            year: 2022,
-            month: 04,
-            day: 7,
         };
         assert!(version.supports_llvm_cov());
     }
@@ -939,9 +924,6 @@ mod tests {
             major: 1,
             minor: 48,
             channel: Channel::Stable,
-            year: 2020,
-            month: 10,
-            day: 14,
         };
         assert!(!version.supports_llvm_cov());
         version.channel = Channel::Beta;


### PR DESCRIPTION
Cargo from distro packages does not contain a date, which results in the version not getting parsed.

e.g.:
```
$ cargo --version
cargo 1.66.1
```
The date is not being used anywhere, so I just removed it.

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
