### PR TITLE
Fix include-tests

### DIFF
--- a/src/source_analysis/attributes.rs
+++ b/src/source_analysis/attributes.rs
@@ -26,7 +26,7 @@ impl SourceAnalysis {
                         let mut skip = false;
                         for c in &ml.nested {
                             if let NestedMeta::Meta(Meta::Path(ref i)) = c {
-                                skip |= i.is_ident("test") && ctx.config.ignore_tests();
+                                skip |= i.is_ident("test") && !ctx.config.include_tests();
                             }
                         }
                         if skip {

--- a/src/source_analysis/items.rs
+++ b/src/source_analysis/items.rs
@@ -59,7 +59,7 @@ impl SourceAnalysis {
                     }
                     check_insides = false;
                     break;
-                } else if ctx.config.ignore_tests() && x.path().is_ident("cfg") {
+                } else if !ctx.config.include_tests() && x.path().is_ident("cfg") {
                     if let Meta::List(ref ml) = x {
                         for nested in &ml.nested {
                             if let NestedMeta::Meta(Meta::Path(ref i)) = *nested {
@@ -119,7 +119,7 @@ impl SourceAnalysis {
             }
         }
         if ignore_span
-            || (test_func && ctx.config.ignore_tests())
+            || (test_func && !ctx.config.include_tests())
             || (ignored_attr && !ctx.config.run_ignored)
         {
             let analysis = self.get_line_analysis(ctx.file.to_path_buf());

--- a/src/source_analysis/mod.rs
+++ b/src/source_analysis/mod.rs
@@ -321,7 +321,7 @@ impl SourceAnalysis {
         filtered_files: &mut HashSet<PathBuf>,
     ) {
         if let Some(file) = path.to_str() {
-            let skip_cause_test = config.ignore_tests() && path.starts_with(root.join("tests"));
+            let skip_cause_test = !config.include_tests() && path.starts_with(root.join("tests"));
             let skip_cause_example = path.starts_with(root.join("examples"))
                 && !config.run_types.contains(&RunType::Examples);
             if (skip_cause_test || skip_cause_example) || self.is_ignored_module(path) {

--- a/src/source_analysis/tests.rs
+++ b/src/source_analysis/tests.rs
@@ -387,9 +387,9 @@ fn filter_macros() {
 #[test]
 fn filter_tests() {
     let mut config = Config::default();
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     let mut igconfig = Config::default();
-    igconfig.set_ignore_tests(true);
+    igconfig.set_include_tests(false);
 
     let ctx = Context {
         config: &config,
@@ -452,7 +452,7 @@ fn filter_tests() {
 #[test]
 fn filter_nonstd_tests() {
     let mut igconfig = Config::default();
-    igconfig.set_ignore_tests(true);
+    igconfig.set_include_tests(false);
 
     let ctx = Context {
         config: &igconfig,
@@ -521,7 +521,7 @@ fn filter_nonstd_tests() {
 #[test]
 fn filter_test_utilities() {
     let mut config = Config::default();
-    config.set_ignore_tests(true);
+    config.set_include_tests(false);
 
     let ctx = Context {
         config: &config,
@@ -543,7 +543,7 @@ fn filter_test_utilities() {
     assert!(lines.ignore.contains(&Lines::Line(4)));
 
     let mut config = Config::default();
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
 
     let ctx = Context {
         config: &config,

--- a/src/test_loader.rs
+++ b/src/test_loader.rs
@@ -285,7 +285,7 @@ fn get_line_addresses<'data: 'file, 'file>(
                 let temp_map = temp_map
                     .into_iter()
                     .filter(|(ref k, _)| {
-                        !(config.ignore_tests() && k.path.starts_with(project.join("tests")))
+                        !(!config.include_tests() && k.path.starts_with(project.join("tests")))
                     })
                     .filter(|(ref k, _)| !(config.exclude_path(&k.path)))
                     .filter(|(ref k, _)| {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -145,7 +145,7 @@ pub fn check_percentage_with_config(
 
 pub fn check_percentage(project_name: &str, minimum_coverage: f64, has_lines: bool) -> TraceMap {
     let mut config = Config::default();
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     config.set_clean(false);
     check_percentage_with_config(project_name, minimum_coverage, has_lines, config)
 }
@@ -198,7 +198,7 @@ fn llvm_sanity_test() {
     let mut config = Config::default();
     config.set_engine(TraceEngine::Llvm);
     config.follow_exec = true;
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     config.set_clean(false);
 
     check_percentage_with_config("structs", 1.0f64, true, config.clone());
@@ -335,7 +335,7 @@ fn examples_coverage() {
     let mut config = Config::default();
     config.run_types = vec![RunType::Examples];
     config.set_clean(false);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     check_percentage_with_config(test, 1.0f64, true, config.clone());
 
     config.run_types.clear();
@@ -442,7 +442,7 @@ fn handle_module_level_exclude_attrs() {
 fn handle_forks() {
     let mut config = Config::default();
     config.set_clean(false);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     config.post_test_delay = Some(Duration::from_secs(10));
     // Some false negatives on more recent compilers so lets just aim for >90% and 0 return code
     check_percentage_with_config("fork-test", 0.85f64, true, config);
@@ -466,7 +466,7 @@ fn dot_rs_in_dir_name() {
     // issue #857
     let mut config = Config::default();
     config.set_clean(false);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
 
     let restore_dir = env::current_dir().unwrap();
     let test_dir = get_test_path("not_a_file.rs");
@@ -497,7 +497,7 @@ fn kill_used_in_test() {
 
     config.follow_exec = true;
     config.set_clean(false);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     // Currently 2 false negatives, but if it was only covering the integration test max coverage
     // is 75% so this is high enough to prove it works
     check_percentage_with_config("kill_proc", 0.9f64, true, config);
@@ -532,7 +532,7 @@ fn sanitised_paths() {
     let report_dir = test_dir.join("reports");
     let mut config = Config::default();
     config.set_engine(TraceEngine::Llvm);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     config.set_clean(false);
     config.generate.push(OutputFile::Lcov);
     config.generate.push(OutputFile::Html);
@@ -584,7 +584,7 @@ fn output_dir_workspace() {
     let report_dir = test_dir.join("reports");
     let mut config = Config::default();
     config.set_engine(TraceEngine::Llvm);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     config.set_clean(false);
     config.dump_traces = true;
     config.generate.push(OutputFile::Lcov);
@@ -652,7 +652,7 @@ fn stripped_crate() {
 fn workspace_no_fail_fast() {
     let mut config = Config::default();
     config.set_clean(false);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     config.no_fail_fast = true;
 
     let test_dir = get_test_path("workspace_with_fail_tests");

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -15,7 +15,7 @@ fn mix_test_types() {
     // ran. This test covers against that mistake
     let mut config = Config::default();
     config.set_clean(true);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
     config.test_timeout = Duration::from_secs(60);
     config.run_types = vec![RunType::Tests, RunType::Examples];
     config.set_profraw_folder(PathBuf::from("mix_test_types"));

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -16,7 +16,7 @@ fn package_exclude() {
     manifest.push("Cargo.toml");
     config.set_manifest(manifest);
     config.set_clean(false);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
 
     config.all = true;
     let result = launch_tarpaulin(&config, &None);
@@ -47,7 +47,7 @@ fn package_exclude() {
 fn specify_package() {
     let mut config = Config::default();
     config.set_clean(false);
-    config.set_ignore_tests(false);
+    config.set_include_tests(true);
 
     let test_dir = get_test_path("workspace");
     env::set_current_dir(&test_dir).unwrap();


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

### Reason for this PR

This commit 343e912bf33a3872ff9f49d48686831d7ca701da made `ignore-tests` the default flag and added `include-tests` flag to reapply the old behaviour. But, the [ignore_tests](https://github.com/xd009642/tarpaulin/commit/343e912bf33a3872ff9f49d48686831d7ca701da#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aR392) function will always return `true` even if `include-tests` is set. This is because of the logical OR operator `||` used.

### Description of changes

- Removed `ignore_tests` from `Config` as both `ignore_tests` and `include_tests` are inverse to each other and can be deferred from a single boolean. 
- Removed `set_ignore_tests` and added `set_include_tests`.
- Removed `ignore_tests` and added `include_tests`.
- Made required changes to use the new  `set_include_tests` and `include_tests`.