### PR TITLE
added option to fail immediately after single test fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ From 2019 onwards, all notable changes to tarpaulin will be documented in this
 file.
 
 ## [Unreleased]
+### Added
+- Added `--fail-immediately` flag to abort execution the moment the first test failure occurs
+
+### Changed
+
+## [Unreleased]
 ### Changed
 - Upgraded from clap v2 to v4. This has a few changes, notably any arguments which can be specified more
 than once require multiple entries so `--run-types doc test` needs to be turned into `--run-types doc --run-types test`

--- a/src/args.rs
+++ b/src/args.rs
@@ -201,6 +201,9 @@ pub struct ConfigArgs {
     /// CI server being used, if unspecified tarpaulin may automatically infer for coveralls uploads
     #[arg(long, value_name = "SERVICE")]
     pub ciserver: Option<Ci>,
+    /// Option to fail immediately after a single test fails
+    #[arg(long)]
+    pub fail_immediately: bool,
     /// Arguments to be passed to the test executables can be used to filter or skip certain tests
     #[arg(last = true)]
     pub args: Vec<String>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -343,7 +343,7 @@ impl From<ConfigArgs> for ConfigWrapper {
             post_test_delay: args.post_test_delay.map(Duration::from_secs),
             objects: canonicalize_paths(args.objects),
             profraw_folder: PathBuf::from("profraws"),
-            fail_immediately: args.fail_immediately
+            fail_immediately: args.fail_immediately,
         };
         if args.ignore_config {
             Self(vec![args_config])

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -186,6 +186,8 @@ pub struct Config {
     objects: Vec<PathBuf>,
     /// Joined to target/tarpaulin to store profraws
     profraw_folder: PathBuf,
+    /// Option to fail immediately after single test fails
+    pub fail_immediately: bool,
 }
 
 fn default_test_timeout() -> Duration {
@@ -255,6 +257,7 @@ impl Default for Config {
             post_test_delay: Some(Duration::from_secs(1)),
             objects: vec![],
             profraw_folder: PathBuf::from("profraws"),
+            fail_immediately: false,
         }
     }
 }
@@ -340,6 +343,7 @@ impl From<ConfigArgs> for ConfigWrapper {
             post_test_delay: args.post_test_delay.map(Duration::from_secs),
             objects: canonicalize_paths(args.objects),
             profraw_folder: PathBuf::from("profraws"),
+            fail_immediately: args.fail_immediately
         };
         if args.ignore_config {
             Self(vec![args_config])

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -186,7 +186,7 @@ pub struct Config {
     objects: Vec<PathBuf>,
     /// Joined to target/tarpaulin to store profraws
     profraw_folder: PathBuf,
-    /// Option to fail immediately after single test fails
+    /// Option to fail immediately after a single test fails
     pub fail_immediately: bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,8 +301,7 @@ pub fn launch_tarpaulin(
                 }
             }
 
-
-            if config.fail_immediately && return_code != 0{
+            if config.fail_immediately && return_code != 0 {
                 return Err(RunError::TestFailed);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,11 @@ pub fn launch_tarpaulin(
                     return_code |= res.1;
                 }
             }
+
+
+            if config.fail_immediately && return_code != 0{
+                return Err(RunError::TestFailed);
+            }
         }
         result.dedup();
     }


### PR DESCRIPTION
When running code coverage on bigger projects, if test fails, tests for all other libraries and binaries are still runned, it would be nice to have a option to fail immediately after single test fails, like `cargo test` does.

Closes #1373