### PR TITLE
Update Cargo.toml to allow cargo-binstall on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ lcov = "0.8.1"
 rusty-fork = "0.3.0"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ target }.tar.gz"
+pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ target }{ archive-suffix }"
 bin-dir = "cargo-tarpaulin{ binary-ext }"
 pkg-fmt = "tgz"
 


### PR DESCRIPTION
`cargo binstall cargo-tarpaulin` currently installs from source on Windows, despite releases being available for that platform in the repository.

The root cause is that the `.tar.gz` extension is explicitly specified in the `pkg-url` under `[package.metadata.binstall]`.

Replacing that extension with `{ archive-suffix }` is sufficient to make this work.

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
