### PR TITLE
update linux.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 From 2019 onwards, all notable changes to tarpaulin will be documented in this
 file.
 
+## [Unreleased]
+### Changed
+- Don't disable ASLR if it's already disabled
+
 ## [0.27.0] 2023-09-17
 ### Added
 - Added `--fail-immediately` flag to abort execution the moment the first test failure occurs

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -62,15 +62,18 @@ fn disable_aslr() -> nix::Result<()> {
     personality::set(this | personality::Persona::ADDR_NO_RANDOMIZE).map(|_| ())
 }
 
-fn is_aslr_enabled() -> bool {   
-    // Create a Command instance with the 'cat' command and the path to the file as arguments   
-    let output = Command::new("cat").arg("/proc/sys/kernel/random/boot_random").output().unwrap();   
+fn is_aslr_enabled() -> bool {
+    // Create a Command instance with the 'cat' command and the path to the file as arguments
+    let output = Command::new("cat")
+        .arg("/proc/sys/kernel/random/boot_random")
+        .output()
+        .unwrap();
 
-    // Convert the output to a String and store it in a variable   
-    let output_str = String::from_utf8(output.stdout).unwrap();   
+    // Convert the output to a String and store it in a variable
+    let output_str = String::from_utf8(output.stdout).unwrap();
 
-    // Check if the output string is not '0' (case-insensitive) and return the result   
-    output_str.trim().to_lowercase() != "0"   
+    // Check if the output string is not '0' (case-insensitive) and return the result
+    output_str.trim().to_lowercase() != "0"
 }
 
 pub fn limit_affinity() -> nix::Result<()> {
@@ -96,8 +99,8 @@ pub fn execute(
     envar: &[(String, String)],
 ) -> Result<TestHandle, RunError> {
     let program = CString::new(test.display().to_string()).unwrap_or_default();
-	if is_aslr_enabled() {
-	    disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {e}")))?;
+    if is_aslr_enabled() {
+        disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {e}")))?;
     }
     request_trace().map_err(|e| RunError::Trace(e.to_string()))?;
 

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -11,6 +11,7 @@ use nix::sys::personality;
 use nix::unistd::*;
 use std::ffi::{CStr, CString};
 use std::path::Path;
+use std::process::Command;
 use tracing::{info, warn};
 
 lazy_static! {
@@ -61,6 +62,17 @@ fn disable_aslr() -> nix::Result<()> {
     personality::set(this | personality::Persona::ADDR_NO_RANDOMIZE).map(|_| ())
 }
 
+fn is_aslr_enabled() -> bool {   
+    // Create a Command instance with the 'cat' command and the path to the file as arguments   
+    let output = Command::new("cat").arg("/proc/sys/kernel/random/boot_random").output().unwrap();   
+
+    // Convert the output to a String and store it in a variable   
+    let output_str = String::from_utf8(output.stdout).unwrap();   
+
+    // Check if the output string is not '0' (case-insensitive) and return the result   
+    output_str.trim().to_lowercase() != "0"   
+}
+
 pub fn limit_affinity() -> nix::Result<()> {
     let this = Pid::this();
     // Get current affinity to be able to limit the cores to one of
@@ -84,8 +96,9 @@ pub fn execute(
     envar: &[(String, String)],
 ) -> Result<TestHandle, RunError> {
     let program = CString::new(test.display().to_string()).unwrap_or_default();
-    disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {e}")))?;
-
+	if is_aslr_enabled() {
+	    disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {e}")))?;
+    }
     request_trace().map_err(|e| RunError::Trace(e.to_string()))?;
 
     let envar = envar


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
Optimization: If ASLR is already turned off, the disable_aslr() function will no longer be called.
This can expand the usage scenarios of tarpaulin. For example, after the root permission administrator shuts down the server ASLR, ordinary users can still use tarpaulin normally even if they cannot obtain root permission~