### PR TITLE
Fail decreasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ file.
 ## [Unreleased]
 ### Changed
 - Don't disable ASLR if it's already disabled
+- Add the `--fail-decreasing` commandline option, which will make tarpaulin return an error
+  if the test coverage has decreased.
 
 ## [0.27.1] 2023-10-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ file.
 - Don't disable ASLR if it's already disabled
 - Add the `--fail-decreasing` commandline option, which will make tarpaulin return an error
   if the test coverage has decreased.
+  If used in combination with `--fail-under`, and the coverage percentage is increasing,
+  pass the run, if we are above the threshold specified, allow the coverage percentage to
+  increase and decrease within that window.
 
 ## [0.27.1] 2023-10-02
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Developers Wiki](https://img.shields.io/badge/development-wiki-yellowgreen.svg)](https://github.com/xd009642/tarpaulin/wiki/Developers)
 [![Coverage Status](https://coveralls.io/repos/github/xd009642/tarpaulin/badge.svg?branch=develop)](https://coveralls.io/github/xd009642/tarpaulin?branch=develop)
 
-Tarpaulin is a code coverage reporting tool for the Cargo build system, named 
+Tarpaulin is a code coverage reporting tool for the Cargo build system, named
 for a waterproof cloth used to cover cargo on a ship.
 
 Currently, tarpaulin
-provides working line coverage, and while fairly reliable, may still contain 
+provides working line coverage, and while fairly reliable, may still contain
 minor inaccuracies in the results. A lot of work has been done to get it
 working on a wide range of projects, but unique combinations of packages
 and build features can cause issues, so please report anything
@@ -69,6 +69,7 @@ Options:
       --skip-clean                 The opposite of --force-clean
       --force-clean                Adds a clean stage to work around cargo bugs that may affect coverage results
       --fail-under <PERCENTAGE>    Sets a percentage threshold for failure ranging from 0-100, if coverage is below exit with a non-zero code
+      --fail-decreasing            Fail if the covarage percentage is decreasing
   -b, --branch                     Branch coverage: NOT IMPLEMENTED
   -f, --forward                    Forwards unexpected signals to test. This is now the default behaviour
       --coveralls <KEY>            Coveralls key, either the repo token, or if you're using travis use $TRAVIS_JOB_ID and specify travis-{ci|pro} in --ciserver
@@ -120,7 +121,7 @@ caused by SIGSTOP, SIGSEGV or SIGILL to the test binary.
 ### Nuances with LLVM Coverage
 
 Despite generally being far more accurate there are some nuances with the LLVM
-coverage instrumentation. 
+coverage instrumentation.
 
 1. If a test has a non-zero exit code coverage data isn't returned
 2. Some areas of thread unsafety
@@ -175,7 +176,7 @@ cargo binstall cargo-tarpaulin
 
 ### Environment Variables
 
-When tarpaulin runs your tests it strives to run them in the same environment as if they were ran via cargo test. 
+When tarpaulin runs your tests it strives to run them in the same environment as if they were ran via cargo test.
 In order to achieve this it sets the following environment variables when executing the test binaries:
 
 - **RUST_BACKTRACE**      - _When --verbose flag is used_
@@ -235,7 +236,7 @@ Jan 30 21:43:35.563  INFO cargo_tarpaulin::report: Coverage Results:
 || Tested/Total Lines:
 || src/lib.rs: 3/4
 || src/unused.rs: 0/3
-|| 
+||
 42.86% coverage, 3/7 lines covered
 ```
 
@@ -266,7 +267,7 @@ Jan 30 21:45:38.990  INFO cargo_tarpaulin::report: Coverage Results:
 || Tested/Total Lines:
 || src/lib.rs: 3/4 +0.00%
 || src/unused.rs: 3/3 +100.00%
-|| 
+||
 85.71% coverage, 6/7 lines covered, +42.86% change in coverage
 ```
 
@@ -332,7 +333,7 @@ fn ignored_by_tarpaulin() {
 There is also nightly support for using tool attributes with tarpaulin for
 skip. For example:
 
-```Rust 
+```Rust
 #![feature(register_tool)]
 #![register_tool(tarpaulin)]
 
@@ -629,6 +630,6 @@ accuracy. If you see missing lines or files, check your compiler version.
 ## License
 
 Tarpaulin is currently licensed under the terms of both the MIT license and the
-Apache License (Version 2.0). See LICENSE-MIT and LICENSE-APACHE for more 
+Apache License (Version 2.0). See LICENSE-MIT and LICENSE-APACHE for more
 details.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options:
       --skip-clean                 The opposite of --force-clean
       --force-clean                Adds a clean stage to work around cargo bugs that may affect coverage results
       --fail-under <PERCENTAGE>    Sets a percentage threshold for failure ranging from 0-100, if coverage is below exit with a non-zero code
-      --fail-decreasing            Fail if the covarage percentage is decreasing
+      --fail-decreasing            Fail if the covarage percentage is decreasing, if used in combination with `--fail-under`, then the tests passes under the threshold, as long as the covarage isn't decreasing, above the threshold it may increase or decrease
   -b, --branch                     Branch coverage: NOT IMPLEMENTED
   -f, --forward                    Forwards unexpected signals to test. This is now the default behaviour
       --coveralls <KEY>            Coveralls key, either the repo token, or if you're using travis use $TRAVIS_JOB_ID and specify travis-{ci|pro} in --ciserver

--- a/src/args.rs
+++ b/src/args.rs
@@ -96,7 +96,9 @@ pub struct ConfigArgs {
     /// Sets a percentage threshold for failure ranging from 0-100, if coverage is below exit with a non-zero code
     #[arg(long, value_name = "PERCENTAGE")]
     pub fail_under: Option<f64>,
-    /// Fail if the covarage percentage is decreasing
+    /// Fail if the covarage percentage is decreasing, if used in combination with `--fail-under`,
+    /// then the tests passes under the threshold, as long as the covarage isn't decreasing, above
+    /// the threshold it may increase or decrease
     #[arg(long)]
     pub fail_decreasing: bool,
     /// Branch coverage: NOT IMPLEMENTED

--- a/src/args.rs
+++ b/src/args.rs
@@ -96,6 +96,9 @@ pub struct ConfigArgs {
     /// Sets a percentage threshold for failure ranging from 0-100, if coverage is below exit with a non-zero code
     #[arg(long, value_name = "PERCENTAGE")]
     pub fail_under: Option<f64>,
+    /// Fail if the covarage percentage is decreasing
+    #[arg(long)]
+    pub fail_decreasing: bool,
     /// Branch coverage: NOT IMPLEMENTED
     #[arg(long, short)]
     pub branch: bool,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -156,6 +156,9 @@ pub struct Config {
     /// returns a non-zero code if coverage is below the threshold
     #[serde(rename = "fail-under")]
     pub fail_under: Option<f64>,
+    /// returns a non-zero code if coverage is decreasing
+    #[serde(rename = "fail-decreasing")]
+    pub fail_decreasing: bool,
     /// Result of cargo_metadata ran on the crate
     #[serde(skip_deserializing, skip_serializing)]
     pub metadata: RefCell<Option<Metadata>>,
@@ -248,6 +251,7 @@ impl Default for Config {
             no_fail_fast: false,
             profile: None,
             fail_under: None,
+            fail_decreasing: false,
             metadata: RefCell::new(None),
             avoid_cfg_tarpaulin: false,
             jobs: None,
@@ -334,6 +338,7 @@ impl From<ConfigArgs> for ConfigWrapper {
             bench_names: args.bench.into_iter().collect(),
             example_names: args.example.into_iter().collect(),
             fail_under: args.fail_under,
+            fail_decreasing: args.fail_decreasing,
             jobs: args.jobs,
             profile: args.profile,
             metadata: RefCell::new(None),
@@ -670,6 +675,10 @@ impl Config {
             || other.fail_under.is_some() && other.fail_under.unwrap() < self.fail_under.unwrap()
         {
             self.fail_under = other.fail_under;
+        }
+
+        if !self.fail_decreasing || other.fail_decreasing {
+            self.fail_decreasing = other.fail_decreasing;
         }
 
         if other.test_timeout != default_test_timeout() {

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -72,7 +72,7 @@ impl Display for RunError {
                     "Coverage is below the failure threshold {a:.2}% < {e:.2}%"
                 )
             }
-            Self::CoverageDecreasing(d) => write!(f, "The coverage has decreased by {d:.2}"),
+            Self::CoverageDecreasing(d) => write!(f, "The coverage has decreased by {d:.2}%"),
             Self::Engine(s) => write!(f, "Engine error: {s}"),
         }
     }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -35,6 +35,8 @@ pub enum RunError {
     Internal,
     /// Tuple of actual coverage and threshold
     BelowThreshold(f64, f64),
+    /// Coverage is decreasing
+    CoverageDecreasing(f64),
     /// Error relating to tracing engine selected
     Engine(String),
 }
@@ -70,6 +72,7 @@ impl Display for RunError {
                     "Coverage is below the failure threshold {a:.2}% < {e:.2}%"
                 )
             }
+            Self::CoverageDecreasing(d) => write!(f, "The coverage has decreased by {d:.2}"),
             Self::Engine(s) => write!(f, "Engine error: {s}"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,7 @@ fn get_delta(config: &Config, trace: &TraceMap) -> f64 {
     let last = last.coverage_percentage() * 100.0f64;
     let current = trace.coverage_percentage() * 100.0f64;
 
-    let delta = current - last;
-    delta
+    current - last
 }
 
 fn check_fail_threshold(traces: &TraceMap, config: &Config) -> Result<(), RunError> {
@@ -263,6 +262,8 @@ fn check_coverage(delta: f64, config: &Config, trace: &TraceMap) -> Result<(), R
         if config.fail_decreasing {
             if decreasing.is_ok() {
                 return Ok(());
+            } else {
+                return decreasing;
             }
         }
         error!("{}", threshold);
@@ -271,7 +272,7 @@ fn check_coverage(delta: f64, config: &Config, trace: &TraceMap) -> Result<(), R
 
     // If both (--fail-under & --fail-decreasing) are used together, allow the coverage to both
     // increase and decrease, as long as we are above the threshold.
-    if threshold.is_ok() && config.fail_decreasing {
+    if threshold.is_ok() && config.fail_under.is_some() {
         return Ok(());
     }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -56,6 +56,21 @@ pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunErro
     }
 }
 
+/// Returns the changed test coverage perentage, used in combination with the --fail-decreasing
+/// command line argument
+pub fn report_delta(config: &Config, result: &TraceMap) -> f64 {
+    let last = match get_previous_result(config) {
+        Some(l) => l,
+        None => TraceMap::new(),
+    };
+
+    let last = last.coverage_percentage() * 100.0f64;
+    let current = result.coverage_percentage() * 100.0f64;
+
+    let delta = current - last;
+    delta
+}
+
 fn generate_requested_reports(config: &Config, result: &TraceMap) -> Result<(), RunError> {
     if config.is_coveralls() {
         coveralls::export(result, config)?;

--- a/tests/failure_thresholds.rs
+++ b/tests/failure_thresholds.rs
@@ -5,7 +5,7 @@ use cargo_tarpaulin::{
 };
 use cargo_tarpaulin::{run, setup_logging};
 use rusty_fork::rusty_fork_test;
-use std::{env, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 rusty_fork_test! {
 
@@ -80,6 +80,278 @@ fn report_coverage_fail() {
     } else {
         panic!("Wrong error type {}", result.unwrap_err());
     }
+}
+
+#[test]
+fn coverage_increasing() {
+    // NOTE: This test uses a seperate target directory, or else it clashes with other test and
+    // produces random failures, further more it removes data from previous runs for the same
+    // reason to give it a clean environment.
+    setup_logging(Color::Never, false, false);
+
+    let test_dir = get_test_path("configs");
+    env::set_current_dir(&test_dir).unwrap();
+
+    let mut target_dir = test_dir.clone();
+    target_dir.push("target/coverage_increasing");
+
+    let mut manifest = test_dir;
+    manifest.push("Cargo.toml");
+
+    // Prepare our steps
+    let step1 = String::from("feature1");
+    let step2 = String::from("feature1 feature2");
+
+    // Prepare our configuration
+    let mut config = Config::default();
+    config.set_manifest(manifest);
+    config.fail_decreasing = true;
+    config.set_clean(false);
+    config.set_target_dir(target_dir.clone());
+
+    // Set a clean base line
+    if target_dir.exists() {
+        fs::remove_dir_all(target_dir).ok();
+    }
+
+    // Start step #1
+    config.features = Some(step1);
+    let result = run(&[config.clone()]);
+    assert!(result.is_ok());
+
+    // Start step #2
+    config.features = Some(step2);
+    let result = run(&[config]);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn coverage_decreasing() {
+    // NOTE: This test uses a seperate target directory, or else it clashes with other test and
+    // produces random failures, further more it removes data from previous runs for the same
+    // reason to give it a clean environment.
+    setup_logging(Color::Never, false, false);
+
+    let test_dir = get_test_path("configs");
+    env::set_current_dir(&test_dir).unwrap();
+
+    let mut target_dir = test_dir.clone();
+    target_dir.push("target/coverage_decreasing");
+
+    let mut manifest = test_dir;
+    manifest.push("Cargo.toml");
+
+    // Prepare our steps
+    let step1 = String::from("feature1 feature2");
+    let step2 = String::from("feature1");
+
+    // Prepare our configuration
+    let mut config = Config::default();
+    config.set_manifest(manifest);
+    config.fail_decreasing = true;
+    config.set_clean(false);
+    config.set_target_dir(target_dir.clone());
+
+    // Set a clean base line
+    if target_dir.exists() {
+        fs::remove_dir_all(target_dir).ok();
+    }
+
+    // Start step #1
+    config.features = Some(step1);
+    let result = run(&[config.clone()]);
+    assert!(result.is_ok());
+
+    // Start step #2
+    config.features = Some(step2);
+    let result = run(&[config]);
+    assert!(result.is_err());
+    if let Err(RunError::CoverageDecreasing(delta)) = result {
+        assert!(delta < 0.0f64);
+        assert_eq!(delta as isize, -50);
+    } else {
+        panic!("Wrong error type {}", result.unwrap_err());
+    }
+}
+
+#[test]
+fn coverage_increasing_below_threshold() {
+    // NOTE: This test uses a seperate target directory, or else it clashes with other test and
+    // produces random failures, further more it removes data from previous runs for the same
+    // reason to give it a clean environment.
+    setup_logging(Color::Never, false, false);
+
+    let test_dir = get_test_path("configs");
+    env::set_current_dir(&test_dir).unwrap();
+
+    let mut target_dir = test_dir.clone();
+    target_dir.push("target/coverage_increasing_below_threshold");
+
+    let mut manifest = test_dir;
+    manifest.push("Cargo.toml");
+
+    // Prepare our steps
+    let step1 = String::from("feature1");
+    let step2 = String::from("feature1 feature2");
+
+    // Prepare our configuration
+    let mut config = Config::default();
+    config.set_manifest(manifest);
+    config.fail_under = Some(70.0f64);
+    config.fail_decreasing = true;
+    config.set_clean(false);
+    config.set_target_dir(target_dir.clone());
+
+    // Set a clean base line
+    if target_dir.exists() {
+        fs::remove_dir_all(target_dir).ok();
+    }
+
+    // Start step 1
+    config.features = Some(step1);
+    let result = run(&[config.clone()]);
+    assert!(result.is_ok());
+
+    // Start step 2
+    config.features = Some(step2);
+    let result = run(&[config]);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn coverage_decreasing_below_threshold() {
+    // NOTE: This test uses a seperate target directory, or else it clashes with other test and
+    // produces random failures, further more it removes data from previous runs for the same
+    // reason to give it a clean environment.
+    setup_logging(Color::Never, false, false);
+
+    let test_dir = get_test_path("configs");
+    env::set_current_dir(&test_dir).unwrap();
+
+    let mut target_dir = test_dir.clone();
+    target_dir.push("target/coverage_decreasing_below_threshold");
+
+    let mut manifest = test_dir.clone();
+    manifest.push("Cargo.toml");
+
+    // Prepare our steps
+    let step1 = String::from("feature1 feature2");
+    let step2 = String::from("feature1");
+
+    // Prepare our configuration
+    let mut config = Config::default();
+    config.set_manifest(manifest);
+    config.fail_under = Some(70.0f64);
+    config.fail_decreasing = true;
+    config.set_target_dir(target_dir.clone());
+
+    // Set a clean base line
+    if target_dir.exists() {
+        fs::remove_dir_all(target_dir).ok();
+    }
+
+    // Start step 1
+    config.features = Some(step1);
+    let result = run(&[config.clone()]);
+    assert!(result.is_ok());
+
+    // Start step 2
+    config.features = Some(step2);
+    let result = run(&[config]);
+    if let Err(RunError::CoverageDecreasing(delta)) = result {
+        assert!(delta < 0.0f64);
+        assert_eq!(delta as isize, -50);
+    } else {
+        panic!("Wrong error type {}", result.unwrap_err());
+    }
+}
+
+#[test]
+fn coverage_increasing_above_threshold() {
+    // NOTE: This test uses a seperate target directory, or else it clashes with other test and
+    // produces random failures, further more it removes data from previous runs for the same
+    // reason to give it a clean environment.
+    setup_logging(Color::Never, false, false);
+
+    let test_dir = get_test_path("configs");
+    env::set_current_dir(&test_dir).unwrap();
+
+    let mut target_dir = test_dir.clone();
+    target_dir.push("target/coverage_increasing_above_threshold");
+
+    let mut manifest = test_dir;
+    manifest.push("Cargo.toml");
+
+    // Prepare our steps
+    let step1 = String::from("feature1");
+    let step2 = String::from("feature1 feature2");
+
+    // Prepare our configuration
+    let mut config = Config::default();
+    config.set_manifest(manifest);
+    config.fail_under = Some(30.0f64);
+    config.fail_decreasing = true;
+    config.set_clean(false);
+    config.set_target_dir(target_dir.clone());
+
+    // Set a clean base line
+    if target_dir.exists() {
+        fs::remove_dir_all(target_dir).ok();
+    }
+
+    // Start step 1
+    config.features = Some(step1);
+    let result = run(&[config.clone()]);
+    assert!(result.is_ok());
+
+    // Start step 2
+    config.features = Some(step2);
+    let result = run(&[config]);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn coverage_decreasing_above_threshold() {
+    // NOTE: This test uses a seperate target directory, or else it clashes with other test and
+    // produces random failures, further more it removes data from previous runs for the same
+    // reason to give it a clean environment.
+    setup_logging(Color::Never, false, false);
+
+    let test_dir = get_test_path("configs");
+    env::set_current_dir(&test_dir).unwrap();
+
+    let mut target_dir = test_dir.clone();
+    target_dir.push("target/coverage_decreasing_above_threshold");
+
+    let mut manifest = test_dir;
+    manifest.push("Cargo.toml");
+
+    // Prepare our steps
+    let step1 = String::from("feature1");
+    let step2 = String::from("feature1 feature2");
+
+    // Prepare our configuration
+    let mut config = Config::default();
+    config.set_manifest(manifest);
+    config.fail_under = Some(30.0f64);
+    config.fail_decreasing = true;
+    config.set_clean(false);
+    config.set_target_dir(target_dir.clone());
+
+    // Set a clean base line
+    if target_dir.exists() {
+        fs::remove_dir_all(target_dir).ok();
+    }
+
+    // Start step 1
+    config.features = Some(step1);
+    let result = run(&[config.clone()]);
+    assert!(result.is_ok());
+
+    // Start step 2
+    config.features = Some(step2);
+    let result = run(&[config]);
+    assert!(result.is_ok());
 }
 
 }


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
This pull request implements the `--fail-decreasing` command line option, which allows tarpaulin to return an error if the coverage percentage has decreased, similar to `--fail-under` which fails the run if the coverage is under a certain threshold.

Current feature set implemented:
- If --fail-under is used by it self, it should behave like before
- If --fail-decreasing is used by it self, it will return an error if the coverage percentage is decreasing.
- If --fail-under and --fail-decreasing is used together is works as follows, if the coverage is below the threshold, it error out if the coverage is decreasing, if the coverage is above the threshold, the coverage can increase and decrease freely.

I have had a quick look at the tests, but are uncertain how and if I should make a test case for this, becaues it would require multi step tests, a first run, one increasing, one returning the same coverage, and one where it is decreasing.

This fixes: #1411

Note: I'm new to rust, so if you have any changes you want made, there could be some terminoligy, that i'm not fluent in or familier with yet :-)