### PR TITLE
docs: fix indentation in coverage workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,29 +441,29 @@ Example how to run coverage within `docker` with `seccomp` in GitHub Actions and
 to <codecov.io>.
 
 ```yml
-name:                           coverage
+name: coverage
 
-on:                             [push]
+on: [push]
 jobs:
   test:
-    name:                       coverage
-    runs-on:                    ubuntu-latest
+    name: coverage
+    runs-on: ubuntu-latest
     container:
-      image:                    xd009642/tarpaulin:develop-nightly
-      options:                  --security-opt seccomp=unconfined
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
     steps:
-      - name:                   Checkout repository
-        uses:                   actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      - name:                   Generate code coverage
+      - name: Generate code coverage
         run: |
           cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
 
-      - name:                   Upload to codecov.io
-        uses:                   codecov/codecov-action@v2
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2
         with:
-          # token:                ${{secrets.CODECOV_TOKEN}} # not required for public repos
-          fail_ci_if_error:     true
+          # token: ${{secrets.CODECOV_TOKEN}} # not required for public repos
+          fail_ci_if_error: true
 ```
 
 #### CircleCI


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

Fixes extra spaces between keys and values to align with the normal styling used throughout the README