### PR TITLE
Make header stick to the top even when scrolling down

### DIFF
--- a/src/report/report_viewer.css
+++ b/src/report/report_viewer.css
@@ -60,6 +60,7 @@ html, body {
   align-items: center;
   position: sticky;
   top: 0;
+  background: white;
 }
 
 .file-header__back {

--- a/src/report/report_viewer.css
+++ b/src/report/report_viewer.css
@@ -58,6 +58,8 @@ html, body {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  position: sticky;
+  top: 0;
 }
 
 .file-header__back {


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

This should fix the first part of #1433.

It keeps the top bar stuck to the top of the window when scrolling down.

The crucial part `sticky` is pretty well supported across browsers. 
https://caniuse.com/css-sticky