### PR TITLE
Line numbers in reports

### DIFF
--- a/src/report/report_viewer.css
+++ b/src/report/report_viewer.css
@@ -88,12 +88,18 @@ html, body {
   margin: 10px 0 0;
   border: 1px solid #999;
   padding: 10px;
+  counter-reset: line;
 }
 
+.code-line::before {
+    content: counter(line);
+    margin-right: 10px;
+}
 .code-line {
   margin: 0;
   padding: 0.3em;
   height: 1em;
+  counter-increment: line;
 }
 .code-line_covered {
   background: #cfc;

--- a/src/report/report_viewer.css
+++ b/src/report/report_viewer.css
@@ -89,6 +89,8 @@ html, body {
   border: 1px solid #999;
   padding: 10px;
   counter-reset: line;
+  display: flex;
+  flex-direction: column;
 }
 
 .code-line::before {

--- a/src/report/report_viewer.js
+++ b/src/report/report_viewer.js
@@ -218,12 +218,12 @@ function FileHeader({file, onBack}) {
 }
 
 function FileContent({file}) {
-  return e('div', {className: 'file-content'},
+  return e('pre', {className: 'file-content'},
     file.content.split(/\r?\n/).map((line, index) => {
       const trace = file.traces.find(trace => trace.line === index + 1);
       const covered = trace && trace.stats.Line;
       const uncovered = trace && !trace.stats.Line;
-      return e('pre', {
+      return e('code', {
           className: 'code-line'
             + (covered ? ' code-line_covered' : '')
             + (uncovered ? ' code-line_uncovered' : ''),


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

Follow up on #1433 to add line numbers.
The line-numbers are done with CSS and will not be selected/copied when selecting/copying code.

Here is a screenshot from the tarpaulin repo
![image](https://github.com/xd009642/tarpaulin/assets/46973479/da955f9f-26cc-4702-8358-f501afaa11e0)