### PR TITLE
Add missing --target to make use of ${{ matrix.target }}

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,9 +32,9 @@ jobs:
       - name: cache
         uses: Swatinem/rust-cache@v2
       - name: test
-        run: cargo test
+        run: cargo test --target ${{ matrix.target }}
       - name: ignored test
-        run: cargo test -- --ignored || true
+        run: cargo test --target ${{ matrix.target }} -- --ignored || true
         if: matrix.version == 'nightly'
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -65,7 +65,7 @@ jobs:
       - name: cache
         uses: Swatinem/rust-cache@v2
       - name: test
-        run: cargo test
+        run: cargo test --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -92,7 +92,7 @@ jobs:
       - name: cache
         uses: Swatinem/rust-cache@v2
       - name: test
-        run: cargo test
+        run: cargo test --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v3
         #if: failure()
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
           components: rustfmt
+          targets: [ ${{ matrix.target }} ]
       - name: cache
         uses: Swatinem/rust-cache@v2
       - name: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           toolchain: ${{ matrix.version }}
           components: rustfmt
-          targets: [ ${{ matrix.target }} ]
+          targets: [ "${{ matrix.target }}" ]
       - name: cache
         uses: Swatinem/rust-cache@v2
       - name: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ walkdir = "2.5.0"
 glob = "0.3.1"
 enum-display = "0.1.4"
 
-[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+[target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
 libc = "0.2.94"
 nix = {version = "0.28.0", default-features = false, features = ["sched", "signal", "ptrace", "personality"]}
 procfs = "0.16"


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

I noticed the build is currently failing on 32bit x86 when trying to [package cargo-tarpaulin for Alpine Linux](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/59413).

In the github actions workflow I noticed there's a test matrix defined for i686, but without `--target` it only runs for the default target (x86_64).