### PR TITLE
Add --package alias to mimic `cargo test` interface

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -124,7 +124,7 @@ pub struct ConfigArgs {
     #[arg(long)]
     pub workspace: bool,
     /// Package id specifications for which package should be build. See cargo help pkgid for more info
-    #[arg(long, short, value_name = "PACKAGE", num_args = 0..)]
+    #[arg(long, short, alias = "package", value_name = "PACKAGE", num_args = 0..)]
     pub packages: Vec<String>,
     /// Package id specifications to exclude from coverage. See cargo help pkgid for more info
     #[arg(long, short, value_name = "PACKAGE", num_args = 0..)]


### PR DESCRIPTION
- cargo test has `--package` and `-p`
- cargo tarpaulin has `--packages` and `-p`

I think it would be nice if cargo tarpaulin also had `--package` as an alias to make it easier going between these tools.

https://github.com/xd009642/tarpaulin/issues/1477