### PR TITLE
Fix `include-test` config to include non-std test

### DIFF
--- a/src/source_analysis/items.rs
+++ b/src/source_analysis/items.rs
@@ -103,7 +103,8 @@ impl SourceAnalysis {
         for attr in &func.attrs {
             if let Ok(x) = attr.parse_meta() {
                 let id = x.path();
-                if id.is_ident("test") {
+                if id.is_ident("test") || id.segments.last().is_some_and(|seg| seg.ident == "test")
+                {
                     test_func = true;
                 } else if id.is_ident("derive") {
                     let analysis = self.get_line_analysis(ctx.file.to_path_buf());


### PR DESCRIPTION
<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
Motivation:
The original issue is sorta described here: https://github.com/xd009642/tarpaulin/issues/351#issuecomment-2036231706. 
But tl;dr version is when `include-tests` is set, `#[tokio::test]` is not covered in the coverage report. 

Changes in this PR:
Added an additional condition to `visit_fn` to check whether the `PathSegment`s ends in `test`, such as `#[tokio::test]` or `#[some_fancy_crate::test]`. 

I tested this tarpaulin version against the issue that I was originally encountering, and it seems to fix it.  
Before where `#[tokio::test]` was ignored: https://app.codecov.io/gh/kube-rs/kube/blob/cov-tweak/kube-runtime%2Fsrc%2Fcontroller%2Ffuture_hash_map.rs#L85
After where it's now included: https://app.codecov.io/gh/tyrone-wu/kube/blob/main/kube-runtime%2Fsrc%2Fcontroller%2Ffuture_hash_map.rs#L85