### PR TITLE
Propagate rustflags to test binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ file.
 - Now override toolchain less-eagerly in windows #1494
 - Fixed build for x86
 - Add summary coverage, covered and coverable to json report #1415
+- Pass RUSTFLAGS to the binary under test for any project bins compiled during test
 
 ## [0.28.0] 2024-04-13
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,8 +922,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 [[package]]
 name = "llvm_profparser"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4171abffcd062e2a9b2f93e79778ca245e20dc94e64304b7175ebe0d6d00f842"
+source = "git+https://github.com/xd009642/llvm-profparser?branch=fix/integration-pains#56b3444e0ef66ef72995d564a4d1065004ce562a"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,8 +921,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "llvm_profparser"
-version = "0.4.0"
-source = "git+https://github.com/xd009642/llvm-profparser?branch=fix/integration-pains#56b3444e0ef66ef72995d564a4d1065004ce562a"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e147b07c8b99a460652903e0cefc82cea62588355a469769a44130dd68e0b896"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ git2 = "0.18"
 humantime-serde = "1"
 indexmap = { version = "~1.8", features = ["serde-1"] }
 lazy_static = "1.0"
-llvm_profparser = "0.4.0"
+#llvm_profparser = "0.4.0"
+llvm_profparser = {  git = "https://github.com/xd009642/llvm-profparser", branch = "fix/integration-pains" }
 object = "0.35"
 num_cpus = "1.16.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ git2 = "0.18"
 humantime-serde = "1"
 indexmap = { version = "~1.8", features = ["serde-1"] }
 lazy_static = "1.0"
-#llvm_profparser = "0.4.0"
-llvm_profparser = {  git = "https://github.com/xd009642/llvm-profparser", branch = "fix/integration-pains" }
+llvm_profparser = "0.5.0"
 object = "0.35"
 num_cpus = "1.16.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,10 @@ pub fn setup_logging(color: Color, debug: bool, verbose: bool) {
                 .add_directive("llvm_profparser=trace".parse().unwrap())
         } else if verbose {
             env.add_directive("cargo_tarpaulin=debug".parse().unwrap())
+                .add_directive("llvm_profparser=warn".parse().unwrap())
         } else {
             env.add_directive("cargo_tarpaulin=info".parse().unwrap())
+                .add_directive("llvm_profparser=error".parse().unwrap())
         }
         .add_directive(LevelFilter::INFO.into())
     };

--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -1,4 +1,5 @@
 use crate::config::Color;
+use crate::cargo::rust_flags;
 use crate::generate_tracemap;
 use crate::path_utils::get_profile_walker;
 use crate::statemachine::{create_state_machine, TestState};
@@ -180,7 +181,7 @@ fn get_env_vars(test: &TestBinary, config: &Config) -> Vec<(String, String)> {
 
     for (key, value) in env::vars() {
         // Avoid adding it twice
-        if key == "LD_LIBRARY_PATH" && test.has_linker_paths() {
+        if key == "LD_LIBRARY_PATH" && test.has_linker_paths() || key == "RUSTFLAGS" {
             continue;
         }
         envars.push((key.to_string(), value.to_string()));
@@ -203,6 +204,7 @@ fn get_env_vars(test: &TestBinary, config: &Config) -> Vec<(String, String)> {
     if test.has_linker_paths() {
         envars.push(("LD_LIBRARY_PATH".to_string(), test.ld_library_path()));
     }
+    envars.push(("RUSTFLAGS".to_string(), rust_flags(config)));
 
     envars
 }

--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -1,5 +1,5 @@
-use crate::config::Color;
 use crate::cargo::rust_flags;
+use crate::config::Color;
 use crate::generate_tracemap;
 use crate::path_utils::get_profile_walker;
 use crate::statemachine::{create_state_machine, TestState};

--- a/src/statemachine/instrumented.rs
+++ b/src/statemachine/instrumented.rs
@@ -132,7 +132,6 @@ impl<'a> StateData for LlvmInstrumentedData<'a> {
                     info!("Mapping coverage data to source");
                     let mapping =
                         CoverageMapping::new(&binaries, &instrumentation, true).map_err(|e| {
-                            info!("Processing binaries: {:?}", binaries);
                             error!("Failed to get coverage: {}", e);
                             RunError::TestCoverage(e.to_string())
                         })?;

--- a/src/statemachine/instrumented.rs
+++ b/src/statemachine/instrumented.rs
@@ -131,7 +131,8 @@ impl<'a> StateData for LlvmInstrumentedData<'a> {
                     binaries.push(binary_path);
                     info!("Mapping coverage data to source");
                     let mapping =
-                        CoverageMapping::new(&binaries, &instrumentation).map_err(|e| {
+                        CoverageMapping::new(&binaries, &instrumentation, true).map_err(|e| {
+                            info!("Processing binaries: {:?}", binaries);
                             error!("Failed to get coverage: {}", e);
                             RunError::TestCoverage(e.to_string())
                         })?;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -34,7 +34,7 @@ pub fn check_percentage_with_cli_args(
     has_lines: bool,
     args: &[String],
 ) -> TraceMap {
-    setup_logging(Color::Never, false, false);
+    setup_logging(Color::Never, true, true);
     let restore_dir = env::current_dir().unwrap();
     let args = TarpaulinCli::parse_from(args);
 
@@ -60,7 +60,7 @@ pub fn check_percentage_with_cli_args(
 }
 
 pub fn run_config(project_name: &str, mut config: Config) {
-    setup_logging(Color::Never, false, false);
+    setup_logging(Color::Never, true, true);
     config.test_timeout = Duration::from_secs(60);
     let restore_dir = env::current_dir().unwrap();
     let test_dir = get_test_path(project_name);
@@ -81,7 +81,7 @@ pub fn check_percentage_with_config(
     has_lines: bool,
     mut config: Config,
 ) -> TraceMap {
-    setup_logging(Color::Never, false, false);
+    setup_logging(Color::Never, true, true);
     config.test_timeout = Duration::from_secs(60);
     let restore_dir = env::current_dir().unwrap();
     let test_dir = get_test_path(project_name);


### PR DESCRIPTION
Also pull in PR branch of llvm-profparsers to let it know it can fail to parse some of the binaries. This issue was caused by spawned processes not having the instrumentation and being included in the affected binary list!

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
