### PR TITLE
Check for RUSTUP_HOME when deciding whether to override the toolchain or not.

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -500,7 +500,8 @@ fn create_command(manifest_path: &str, config: &Config, ty: Option<RunType>) -> 
     let mut test_cmd = Command::new("cargo");
     let bootstrap = matches!(env::var("RUSTC_BOOTSTRAP").as_deref(), Ok("1"));
     let override_toolchain = if cfg!(windows) {
-        if env::var("PATH").unwrap_or_default().contains(".rustup") {
+        let rustup_home = env::var("RUSTUP_HOME").unwrap_or(".rustup".into());
+        if env::var("PATH").unwrap_or_default().contains(&rustup_home) {
             // So the specific cargo we're using is in the path var so rustup toolchains won't
             // work. This only started happening recently so special casing it for older versions
             env::remove_var("RUSTUP_TOOLCHAIN");


### PR DESCRIPTION
Previously, if your rustup was installed to a different location than the default, tarpaulin would erroneously try to add the toolchain. Now it doesn't!

I tested this on my machine and it finally worked. This correctly resolves #1494, though I'm not sure if standard installs will work correctly (they should though).