### PR TITLE
Remove tracing-test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 env:
   RUST_BACKTRACE: 1
+  RUST_LOG: "cargo_tarpaulin=trace,llvm_profparser=trace"
 
 jobs:
   linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,10 +210,10 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.61",
+ "test-log",
  "toml",
  "tracing",
  "tracing-subscriber",
- "tracing-test",
  "walkdir",
 ]
 
@@ -381,6 +381,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -1553,6 +1574,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,29 +1778,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
-dependencies = [
- "lazy_static",
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
-dependencies = [
- "lazy_static",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ rustc_version = "0.4"
 [dev-dependencies]
 lcov = "0.8.1"
 rusty-fork = "0.3.0"
-tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
+test-log = { version = "0.2.16", features = ["trace"] }
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/{ version }/cargo-tarpaulin-{ target }{ archive-suffix }"

--- a/src/source_analysis/tests.rs
+++ b/src/source_analysis/tests.rs
@@ -1,9 +1,8 @@
 use crate::source_analysis::prelude::*;
 use syn::parse_file;
-use tracing_test::traced_test;
+use test_log::test;
 
 #[test]
-#[traced_test]
 fn logical_lines_let_bindings() {
     let config = Config::default();
     let mut analysis = SourceAnalysis::new();
@@ -56,7 +55,6 @@ fn logical_lines_let_bindings() {
 }
 
 #[test]
-#[traced_test]
 fn match_pattern_logical_lines() {
     let config = Config::default();
     let ctx = Context {
@@ -89,7 +87,6 @@ fn match_pattern_logical_lines() {
 }
 
 #[test]
-#[traced_test]
 fn line_analysis_works() {
     let mut la = LineAnalysis::new();
     assert!(!la.should_ignore(0));
@@ -103,7 +100,6 @@ fn line_analysis_works() {
 }
 
 #[test]
-#[traced_test]
 fn filter_str_literals() {
     let config = Config::default();
     let ctx = Context {
@@ -164,7 +160,6 @@ fn filter_str_literals() {
 }
 
 #[test]
-#[traced_test]
 fn filter_struct_members() {
     let config = Config::default();
     let ctx = Context {
@@ -199,7 +194,6 @@ fn filter_struct_members() {
 }
 
 #[test]
-#[traced_test]
 fn filter_enum_members() {
     let config = Config::default();
     let ctx = Context {
@@ -222,7 +216,6 @@ fn filter_enum_members() {
 }
 
 #[test]
-#[traced_test]
 fn filter_struct_consts() {
     let config = Config::default();
     let ctx = Context {
@@ -246,7 +239,6 @@ fn filter_struct_consts() {
 }
 
 #[test]
-#[traced_test]
 fn filter_unreachable_unchecked() {
     let config = Config::default();
     let ctx = Context {
@@ -265,7 +257,6 @@ fn filter_unreachable_unchecked() {
 }
 
 #[test]
-#[traced_test]
 fn filter_loop_attr() {
     let config = Config::default();
     let ctx = Context {
@@ -294,7 +285,6 @@ fn filter_loop_attr() {
 }
 
 #[test]
-#[traced_test]
 fn filter_mods() {
     let config = Config::default();
     let ctx = Context {
@@ -335,7 +325,6 @@ fn filter_mods() {
 }
 
 #[test]
-#[traced_test]
 fn filter_macros() {
     let config = Config::default();
     let ctx = Context {
@@ -397,7 +386,6 @@ fn filter_macros() {
 }
 
 #[test]
-#[traced_test]
 fn filter_tests() {
     let mut config = Config::default();
     config.set_include_tests(true);
@@ -464,7 +452,6 @@ fn filter_tests() {
 }
 
 #[test]
-#[traced_test]
 fn filter_nonstd_tests() {
     let mut igconfig = Config::default();
     igconfig.set_include_tests(false);
@@ -534,7 +521,6 @@ fn filter_nonstd_tests() {
 }
 
 #[test]
-#[traced_test]
 fn include_nonstd_tests() {
     let mut config = Config::default();
     config.set_include_tests(true);
@@ -589,7 +575,6 @@ fn include_nonstd_tests() {
 }
 
 #[test]
-#[traced_test]
 fn filter_test_utilities() {
     let mut config = Config::default();
     config.set_include_tests(false);
@@ -636,7 +621,6 @@ fn filter_test_utilities() {
 }
 
 #[test]
-#[traced_test]
 fn filter_where() {
     let config = Config::default();
     let ctx = Context {
@@ -687,7 +671,6 @@ fn filter_where() {
 }
 
 #[test]
-#[traced_test]
 fn filter_derives() {
     let config = Config::default();
     let ctx = Context {
@@ -716,7 +699,6 @@ fn filter_derives() {
 }
 
 #[test]
-#[traced_test]
 fn filter_unsafe() {
     let config = Config::default();
     let ctx = Context {
@@ -746,7 +728,6 @@ fn filter_unsafe() {
 }
 
 #[test]
-#[traced_test]
 fn cover_generic_impl_methods() {
     let config = Config::default();
     let ctx = Context {
@@ -788,7 +769,6 @@ fn cover_generic_impl_methods() {
 }
 
 #[test]
-#[traced_test]
 fn cover_default_trait_methods() {
     let config = Config::default();
     let ctx = Context {
@@ -810,7 +790,6 @@ fn cover_default_trait_methods() {
 }
 
 #[test]
-#[traced_test]
 fn cover_impl_trait_generic_fns() {
     let config = Config::default();
     let ctx = Context {
@@ -830,7 +809,6 @@ fn cover_impl_trait_generic_fns() {
 }
 
 #[test]
-#[traced_test]
 fn filter_method_args() {
     let config = Config::default();
     let ctx = Context {
@@ -868,7 +846,6 @@ fn filter_method_args() {
 }
 
 #[test]
-#[traced_test]
 fn filter_use_statements() {
     let config = Config::default();
     let ctx = Context {
@@ -887,7 +864,6 @@ fn filter_use_statements() {
 }
 
 #[test]
-#[traced_test]
 fn include_inline_fns() {
     let config = Config::default();
     let ctx = Context {
@@ -917,7 +893,6 @@ fn include_inline_fns() {
 }
 
 #[test]
-#[traced_test]
 fn cover_callable_noargs() {
     let config = Config::default();
     let ctx = Context {
@@ -936,7 +911,6 @@ fn cover_callable_noargs() {
 }
 
 #[test]
-#[traced_test]
 fn filter_closure_contents() {
     let config = Config::default();
     let ctx = Context {
@@ -957,7 +931,6 @@ fn filter_closure_contents() {
 }
 
 #[test]
-#[traced_test]
 fn tarpaulin_skip_attr() {
     let config = Config::default();
     let ctx = Context {
@@ -1039,7 +1012,6 @@ fn tarpaulin_skip_attr() {
 }
 
 #[test]
-#[traced_test]
 fn tarpaulin_skip_trait_attrs() {
     let config = Config::default();
     let ctx = Context {
@@ -1095,7 +1067,6 @@ fn tarpaulin_skip_trait_attrs() {
 }
 
 #[test]
-#[traced_test]
 fn tarpaulin_skip_impl_attrs() {
     let config = Config::default();
     let ctx = Context {
@@ -1154,7 +1125,6 @@ fn tarpaulin_skip_impl_attrs() {
 }
 
 #[test]
-#[traced_test]
 fn filter_block_contents() {
     let config = Config::default();
     let ctx = Context {
@@ -1181,7 +1151,6 @@ fn filter_block_contents() {
 }
 
 #[test]
-#[traced_test]
 fn filter_consts() {
     let config = Config::default();
     let ctx = Context {
@@ -1200,7 +1169,6 @@ fn filter_consts() {
 }
 
 #[test]
-#[traced_test]
 fn optional_panic_ignore() {
     let config = Config::default();
     let ctx = Context {
@@ -1252,7 +1220,6 @@ fn optional_panic_ignore() {
 }
 
 #[test]
-#[traced_test]
 fn filter_nested_blocks() {
     let config = Config::default();
     let ctx = Context {
@@ -1285,7 +1252,6 @@ fn filter_nested_blocks() {
 }
 
 #[test]
-#[traced_test]
 fn filter_multi_line_decls() {
     let config = Config::default();
     let ctx = Context {
@@ -1346,7 +1312,6 @@ fn filter_multi_line_decls() {
 }
 
 #[test]
-#[traced_test]
 fn unreachable_propagate() {
     let config = Config::default();
     let ctx = Context {
@@ -1422,7 +1387,6 @@ fn unreachable_propagate() {
 }
 
 #[test]
-#[traced_test]
 fn unreachable_include_returns() {
     let config = Config::default();
     let ctx = Context {
@@ -1482,7 +1446,6 @@ fn unreachable_include_returns() {
 }
 
 #[test]
-#[traced_test]
 fn unreachable_include_loops() {
     let config = Config::default();
     let ctx = Context {
@@ -1550,7 +1513,6 @@ fn unreachable_include_loops() {
 }
 
 #[test]
-#[traced_test]
 fn single_line_callables() {
     let config = Config::default();
     let ctx = Context {
@@ -1585,7 +1547,6 @@ fn single_line_callables() {
 }
 
 #[test]
-#[traced_test]
 fn visit_generics() {
     let config = Config::default();
     let ctx = Context {
@@ -1632,7 +1593,6 @@ fn visit_generics() {
 }
 
 #[test]
-#[traced_test]
 fn ignore_comment() {
     let config = Config::default();
     let ctx = Context {
@@ -1667,7 +1627,6 @@ fn ignore_comment() {
 }
 
 #[test]
-#[traced_test]
 fn py_attr() {
     let config = Config::default();
     let ctx = Context {
@@ -1704,7 +1663,6 @@ fn py_attr() {
 }
 
 #[test]
-#[traced_test]
 fn handle_c_strs() {
     let config = Config::default();
     let ctx = Context {
@@ -1721,7 +1679,6 @@ fn handle_c_strs() {
 }
 
 #[test]
-#[traced_test]
 fn ignore_trait_types() {
     let config = Config::default();
     let ctx = Context {

--- a/tests/doc_coverage.rs
+++ b/tests/doc_coverage.rs
@@ -4,11 +4,10 @@ use cargo_tarpaulin::launch_tarpaulin;
 use rusty_fork::rusty_fork_test;
 use std::time::Duration;
 use std::{env, path::PathBuf};
-use tracing_test::traced_test;
+use test_log::test;
 
 rusty_fork_test! {
 #[test]
-#[traced_test]
 fn doc_test_env() {
     let mut config = Config::default();
     config.set_clean(false);
@@ -30,7 +29,6 @@ fn doc_test_env() {
 }
 
 #[test]
-#[traced_test]
 fn doc_test_coverage() {
     let mut config = Config::default();
     config.verbose = true;
@@ -61,7 +59,6 @@ fn doc_test_coverage() {
 }
 
 #[test]
-#[traced_test]
 fn doc_test_panics() {
     let mut config = Config::default();
     config.verbose = true;
@@ -92,7 +89,6 @@ fn doc_test_panics() {
 }
 
 #[test]
-#[traced_test]
 fn doc_test_panics_workspace() {
     let mut config = Config::default();
     config.verbose = true;
@@ -123,7 +119,6 @@ fn doc_test_panics_workspace() {
 }
 
 #[test]
-#[traced_test]
 fn doc_test_compile_fail() {
     let mut config = Config::default();
     config.verbose = true;
@@ -141,7 +136,6 @@ fn doc_test_compile_fail() {
 }
 
 #[test]
-#[traced_test]
 fn doc_test_no_run() {
     let mut config = Config::default();
     config.verbose = true;
@@ -160,7 +154,6 @@ fn doc_test_no_run() {
 }
 
 #[test]
-#[traced_test]
 fn rustdocflags_handling() {
     env::set_var("RUSTDOCFLAGS", "--cfg=foo");
     let mut config = Config::default();

--- a/tests/failure_thresholds.rs
+++ b/tests/failure_thresholds.rs
@@ -3,12 +3,11 @@ use cargo_tarpaulin::run;
 use cargo_tarpaulin::{config::Config, errors::RunError};
 use rusty_fork::rusty_fork_test;
 use std::{env, path::PathBuf};
-use tracing_test::traced_test;
+use test_log::test;
 
 rusty_fork_test! {
 
 #[test]
-#[traced_test]
 fn coverage_below_threshold() {
     let mut config = Config::default();
     let test_dir = get_test_path("simple_project");
@@ -32,7 +31,6 @@ fn coverage_below_threshold() {
 }
 
 #[test]
-#[traced_test]
 fn coverage_above_threshold() {
     let mut config = Config::default();
     let test_dir = get_test_path("simple_project");
@@ -50,7 +48,6 @@ fn coverage_above_threshold() {
 }
 
 #[test]
-#[traced_test]
 fn report_coverage_fail() {
     let mut config = Config::default();
     let test_dir = get_test_path("simple_project");

--- a/tests/failures.rs
+++ b/tests/failures.rs
@@ -6,12 +6,11 @@ use cargo_tarpaulin::{
 use cargo_tarpaulin::{launch_tarpaulin, run};
 use rusty_fork::rusty_fork_test;
 use std::env;
-use tracing_test::traced_test;
+use test_log::test;
 
 rusty_fork_test! {
 
 #[test]
-#[traced_test]
 fn error_if_build_script_fails() {
     let mut config = Config::default();
     let test_dir = get_test_path("build_script_fail");
@@ -32,7 +31,6 @@ fn error_if_build_script_fails() {
 }
 
 #[test]
-#[traced_test]
 fn error_if_compilation_fails() {
     let mut config = Config::default();
     let test_dir = get_test_path("compile_fail");
@@ -53,7 +51,6 @@ fn error_if_compilation_fails() {
 }
 
 #[test]
-#[traced_test]
 fn error_if_test_fails() {
     let mut config = Config::default();
     let test_dir = get_test_path("failing_test");
@@ -74,7 +71,6 @@ fn error_if_test_fails() {
 }
 
 #[test]
-#[traced_test]
 fn issue_610() {
     let mut config = Config::default();
     let test_dir = get_test_path("issue_610");

--- a/tests/line_coverage.rs
+++ b/tests/line_coverage.rs
@@ -5,12 +5,11 @@ use cargo_tarpaulin::traces::CoverageStat;
 use rusty_fork::rusty_fork_test;
 use std::env;
 use std::time::Duration;
-use tracing_test::traced_test;
+use test_log::test;
 
 rusty_fork_test! {
 
 #[test]
-#[traced_test]
 fn simple_project_coverage() {
     let mut config = Config::default();
     config.set_clean(false);
@@ -52,7 +51,6 @@ fn simple_project_coverage() {
 }
 
 #[test]
-#[traced_test]
 fn debug_info_0() {
     // From issue #601
     let mut config = Config::default();
@@ -76,7 +74,6 @@ fn debug_info_0() {
 }
 
 #[test]
-#[traced_test]
 fn test_threads_1() {
     let mut config = Config::default();
     config.set_clean(false);

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{env, fs};
-use tracing_test::traced_test;
+use test_log::test;
 
 #[cfg(nightly)]
 mod doc_coverage;
@@ -128,7 +128,6 @@ pub fn check_percentage(project_name: &str, minimum_coverage: f64, has_lines: bo
 rusty_fork_test! {
 
 #[test]
-#[traced_test]
 fn incorrect_manifest_path() {
     let mut config = Config::default();
     let mut invalid = config.manifest();
@@ -140,7 +139,6 @@ fn incorrect_manifest_path() {
 }
 
 #[test]
-#[traced_test]
 fn proc_macro_link() {
     let mut config = Config::default();
     config.test_timeout = Duration::from_secs(60);
@@ -151,19 +149,16 @@ fn proc_macro_link() {
 }
 
 #[test]
-#[traced_test]
 fn array_coverage() {
     check_percentage("arrays", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn lets_coverage() {
     check_percentage("lets", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 #[cfg_attr(not(target_os="linux"), ignore)] // TODO So there are linker issues I can't adequately diagnose myself in windows
 #[cfg(not(tarpaulin))]
 fn picking_up_shared_objects() {
@@ -174,7 +169,6 @@ fn picking_up_shared_objects() {
 
 // Just for linux if we have ptrace as default
 #[test]
-#[traced_test]
 fn llvm_sanity_test() {
     let mut config = Config::default();
     config.set_engine(TraceEngine::Llvm);
@@ -189,74 +183,62 @@ fn llvm_sanity_test() {
 }
 
 #[test]
-#[traced_test]
 fn struct_expr_coverage() {
     check_percentage("structs", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn ifelse_expr_coverage() {
     check_percentage("ifelse", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn returns_expr_coverage() {
     check_percentage("returns", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn loops_expr_coverage() {
     check_percentage("loops", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn loops_assigns_coverage() {
     check_percentage("assigns", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn paths_coverage() {
     check_percentage("paths", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn futures_coverage() {
     check_percentage("futures", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn breaks_expr_coverage() {
     check_percentage("breaks", 0.95f64, true);
 }
 
 #[test]
-#[traced_test]
 fn continues_expr_coverage() {
     check_percentage("continues", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn boxes_coverage() {
     check_percentage("boxes", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 #[ignore]
 fn method_calls_expr_coverage() {
     check_percentage("method_calls", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 #[cfg(not(windows))] // TODO fix
 fn config_file_coverage() {
     let test_dir = get_test_path("configs");
@@ -271,7 +253,6 @@ fn config_file_coverage() {
 }
 
 #[test]
-#[traced_test]
 fn issue_966_follow_exec() {
     let test_dir = get_test_path("follow_exec_issue966");
     let args = vec![
@@ -285,7 +266,6 @@ fn issue_966_follow_exec() {
 }
 
 #[test]
-#[traced_test]
 fn rustflags_config_coverage() {
     let test_dir = get_test_path("multiple_rustflags");
     let mut args = vec![
@@ -299,13 +279,11 @@ fn rustflags_config_coverage() {
 }
 
 #[test]
-#[traced_test]
 fn match_expr_coverage() {
     check_percentage("matches", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 #[ignore]
 fn benchmark_coverage() {
     let test = "benchmark_coverage";
@@ -318,7 +296,6 @@ fn benchmark_coverage() {
 }
 
 #[test]
-#[traced_test]
 fn cargo_run_coverage() {
     let mut config = Config::default();
     config.command = Mode::Build;
@@ -327,7 +304,6 @@ fn cargo_run_coverage() {
 }
 
 #[test]
-#[traced_test]
 #[cfg(not(windows))] // TODO fix
 fn examples_coverage() {
     let test = "example_test";
@@ -345,7 +321,6 @@ fn examples_coverage() {
 }
 
 #[test]
-#[traced_test]
 fn access_env_var() {
     // This test is mainly to check that expected environment variables are present
     // using `CARGO_BIN_EXE_<name>` to test
@@ -354,27 +329,23 @@ fn access_env_var() {
 }
 
 #[test]
-#[traced_test]
 fn tarpaulin_attrs() {
     check_percentage("tarpaulin_attrs", 0.0f64, true);
 }
 
 #[test]
-#[traced_test]
 #[cfg(nightly)]
 fn tarpaulin_tool_attr() {
     check_percentage("tool_attr", 0.0f64, false);
 }
 
 #[test]
-#[traced_test]
 #[cfg(nightly)]
 fn filter_with_inner_attributes() {
     check_percentage("filter_inner_modules", 0.0f64, false);
 }
 
 #[test]
-#[traced_test]
 fn cargo_home_filtering() {
     let new_home =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/HttptestAndReqwest/new_home");
@@ -407,7 +378,6 @@ fn cargo_home_filtering() {
 }
 
 #[test]
-#[traced_test]
 fn rustflags_handling() {
     env::remove_var("RUSTFLAGS");
     check_percentage("rustflags", 1.0f64, true);
@@ -433,7 +403,6 @@ fn rustflags_handling() {
 }
 
 #[test]
-#[traced_test]
 fn follow_exes_down() {
     let mut config = Config::default();
     config.follow_exec = true;
@@ -442,13 +411,11 @@ fn follow_exes_down() {
 }
 
 #[test]
-#[traced_test]
 fn handle_module_level_exclude_attrs() {
     check_percentage("crate_level_ignores", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 #[cfg(unix)]
 fn handle_forks() {
     let mut config = Config::default();
@@ -460,7 +427,6 @@ fn handle_forks() {
 }
 
 #[test]
-#[traced_test]
 fn no_test_args() {
     let test_dir = get_test_path("no_test_args");
     let args = vec![
@@ -474,7 +440,6 @@ fn no_test_args() {
 }
 
 #[test]
-#[traced_test]
 fn dot_rs_in_dir_name() {
     // issue #857
     let mut config = Config::default();
@@ -499,7 +464,6 @@ fn dot_rs_in_dir_name() {
 }
 
 #[test]
-#[traced_test]
 #[cfg(unix)]
 #[cfg(not(tarpaulin))]
 fn kill_used_in_test() {
@@ -519,7 +483,6 @@ fn kill_used_in_test() {
 
 
 #[test]
-#[traced_test]
 fn doc_test_bootstrap() {
     let mut config = Config::default();
     config.verbose = true;
@@ -540,7 +503,6 @@ fn doc_test_bootstrap() {
 }
 
 #[test]
-#[traced_test]
 #[cfg(windows)]
 fn sanitised_paths() {
     let test_dir = get_test_path("assigns");
@@ -593,7 +555,6 @@ fn sanitised_paths() {
 }
 
 #[test]
-#[traced_test]
 fn output_dir_workspace() {
     let test_dir = get_test_path("workspace");
     let report_dir = test_dir.join("reports");
@@ -639,7 +600,6 @@ fn output_dir_workspace() {
 
 
 #[test]
-#[traced_test]
 fn stripped_crate() {
     let mut config = Config::default();
     config.verbose = true;
@@ -651,7 +611,6 @@ fn stripped_crate() {
 
 
 #[test]
-#[traced_test]
 fn workspace_no_fail_fast() {
     let mut config = Config::default();
     config.set_clean(false);
@@ -672,13 +631,11 @@ fn workspace_no_fail_fast() {
 }
 
 #[test]
-#[traced_test]
 fn warning_flags_in_config() {
     check_percentage("config_warnings", 1.0f64, true);
 }
 
 #[test]
-#[traced_test]
 fn workspace_default_members() {
     let mut config = Config::default();
     config.set_clean(false);

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -5,12 +5,11 @@ use rusty_fork::rusty_fork_test;
 use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
-use tracing_test::traced_test;
+use test_log::test;
 
 rusty_fork_test! {
 
 #[test]
-#[traced_test]
 fn mix_test_types() {
     // Issue 747 the clean would delete old tests leaving to only one run type effectively being
     // ran. This test covers against that mistake
@@ -46,7 +45,6 @@ fn mix_test_types() {
 }
 
 #[test]
-#[traced_test]
 fn only_test_coverage() {
     let mut config = Config::default();
     config.set_clean(false);
@@ -78,7 +76,6 @@ fn only_test_coverage() {
 }
 
 #[test]
-#[traced_test]
 fn all_targets_coverage() {
     let mut config = Config::default();
     config.set_clean(false);
@@ -111,7 +108,6 @@ fn all_targets_coverage() {
 
 
 #[test]
-#[traced_test]
 fn only_example_coverage() {
     let mut config = Config::default();
     config.set_clean(false);
@@ -143,7 +139,6 @@ fn only_example_coverage() {
 }
 
 #[test]
-#[traced_test]
 #[ignore]
 fn only_bench_coverage() {
     let mut config = Config::default();
@@ -176,7 +171,6 @@ fn only_bench_coverage() {
 }
 
 #[test]
-#[traced_test]
 #[cfg(feature = "nightly")]
 fn only_doctest_coverage() {
     let mut config = Config::default();

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -4,12 +4,11 @@ use cargo_tarpaulin::launch_tarpaulin;
 use rusty_fork::rusty_fork_test;
 use std::env;
 use std::path::PathBuf;
-use tracing_test::traced_test;
+use test_log::test;
 
 rusty_fork_test! {
 
 #[test]
-#[traced_test]
 fn package_exclude() {
     let mut config = Config::default();
     let test_dir = get_test_path("workspace");
@@ -46,7 +45,6 @@ fn package_exclude() {
 }
 
 #[test]
-#[traced_test]
 fn specify_package() {
     let mut config = Config::default();
     config.set_clean(false);
@@ -80,7 +78,6 @@ fn specify_package() {
 }
 
 #[test]
-#[traced_test]
 fn config_relative_pathing() {
     let mut test_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     test_dir.push("tests");


### PR DESCRIPTION
With this removed the complete removal of syn1.x will be complete once ruztd is released and object is updated to use it (or semver allowing I can just update ruztd myself and object doesn't have to release).

Another important step in eradicating syn1

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
