### PR TITLE
Fixes #1555

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 From 2019 onwards, all notable changes to tarpaulin will be documented in this
 file.
 
+## [Unreleased] 
+### Changed
+- No longer print rustflags for report configs with `--print-rust-flags` 
+
 ## [0.30.0] 2024-05-10
 ### Changed
 - Upgraded to syn2 and removed branch coverage module. This only had impact in debug dumps so shouldn't impact users

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ where
 {
     let mut seen_flags = HashMap::new();
     for config in &config.0 {
+        if config.name == "report" {
+            continue;
+        }
+
         let flags = flags_fn(config);
         seen_flags
             .entry(flags)


### PR DESCRIPTION
No longer print rustflags for report configs with `--print-rust-flags`

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
