### PR TITLE
Fixes #1582

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,8 @@ jobs:
           components: rustfmt
       - name: cache
         uses: Swatinem/rust-cache@v2
+      - name: check_non_default
+        run: cargo check --no-default-features
       - name: test
         run: cargo test
       - uses: actions/upload-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ cargo_metadata = "0.18"
 cfg-if = "1.0.0"
 chrono = "0.4"
 clap = { version = "4.4.0", features = ["derive"] }
-coveralls-api = "0.6.0"
+coveralls-api = { version = "0.6.0", optional = true }
 fallible-iterator = "0.3.0"
 gimli = "0.31.0"
-git2 = "0.19"
+git2 =  { version = "0.19", optional = true }
 humantime-serde = "1"
 indexmap = { version = "~1.8", features = ["serde-1"] }
 lazy_static = "1.5"
@@ -61,8 +61,9 @@ nix = {version = "0.29.0", default-features = false, features = ["sched", "signa
 procfs = "0.16"
 
 [features]
-default = []
-vendored-openssl = ["git2/vendored-openssl"]
+default = ["coveralls"]
+coveralls = ["coveralls-api", "git2"]
+vendored-openssl = ["git2/vendored-openssl", "coveralls"]
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use clap::{Args, Parser};
 use glob::Pattern;
 
-use crate::config::{Ci, Color, Mode, OutputFile, RunType, TraceEngine};
+#[cfg(feature = "coveralls")]
+use crate::config::Ci;
+use crate::config::{Color, Mode, OutputFile, RunType, TraceEngine};
 
 #[derive(Debug, Parser)]
 #[command(name = "cargo-tarpaulin")]
@@ -198,6 +200,7 @@ pub struct ConfigArgs {
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH")]
     pub manifest_path: Option<PathBuf>,
+    #[cfg(feature = "coveralls")]
     /// CI server being used, if unspecified tarpaulin may automatically infer for coveralls uploads
     #[arg(long, value_name = "SERVICE")]
     pub ciserver: Option<Ci>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -314,6 +314,7 @@ impl From<ConfigArgs> for ConfigWrapper {
             generate: args.out,
             output_directory: args.output_dir,
             coveralls: args.coveralls,
+            #[cfg(feature = "coveralls")]
             ci_tool: args.ciserver.map(|c| c.0),
             report_uri: args.report_uri,
             forward_signals: true, // No longer an option
@@ -621,7 +622,13 @@ impl Config {
         }
         self.root = Config::pick_optional_config(&self.root, &other.root);
         self.coveralls = Config::pick_optional_config(&self.coveralls, &other.coveralls);
-        self.ci_tool = Config::pick_optional_config(&self.ci_tool, &other.ci_tool);
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "coveralls")] {
+                self.ci_tool = Config::pick_optional_config(&self.ci_tool, &other.ci_tool);
+            }
+        }
+
         self.report_uri = Config::pick_optional_config(&self.report_uri, &other.report_uri);
         self.target = Config::pick_optional_config(&self.target, &other.target);
         self.target_dir = Config::pick_optional_config(&self.target_dir, &other.target_dir);
@@ -1147,6 +1154,7 @@ mod tests {
         assert_eq!(b.exclude, vec![String::from("b"), String::from("c")]);
     }
 
+    #[cfg(feature = "coveralls")]
     #[test]
     fn coveralls_merge() {
         let toml = r#"[a]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ pub use self::types::*;
 use crate::path_utils::fix_unc_path;
 use crate::{args::ConfigArgs, cargo::supports_llvm_coverage};
 use cargo_metadata::{Metadata, MetadataCommand};
+#[cfg(feature = "coveralls")]
 use coveralls_api::CiService;
 use glob::Pattern;
 use humantime_serde::deserialize as humantime_serde;
@@ -69,6 +70,7 @@ pub struct Config {
     pub coveralls: Option<String>,
     /// Enum representing CI tool used.
     #[serde(rename = "ciserver", deserialize_with = "deserialize_ci_server")]
+    #[cfg(feature = "coveralls")]
     pub ci_tool: Option<CiService>,
     /// Only valid if coveralls option is set. If coveralls option is set,
     /// as well as report_uri, then the report will be sent to this endpoint
@@ -222,6 +224,7 @@ impl Default for Config {
             generate: vec![],
             output_directory: Default::default(),
             coveralls: None,
+            #[cfg(feature = "coveralls")]
             ci_tool: None,
             report_uri: None,
             forward_signals: true,

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -1,5 +1,6 @@
 use crate::config::types::*;
 use crate::path_utils::fix_unc_path;
+#[cfg(feature = "coveralls")]
 use coveralls_api::CiService;
 use serde::de::{self, Deserializer};
 use std::env;
@@ -74,6 +75,7 @@ pub(super) fn canonicalize_path(mut path: PathBuf) -> PathBuf {
     path
 }
 
+#[cfg(feature = "coveralls")]
 pub fn deserialize_ci_server<'de, D>(d: D) -> Result<Option<CiService>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+#[cfg(feature = "coveralls")]
 use coveralls_api::CiService;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -107,9 +108,11 @@ pub enum OutputFile {
     Lcov,
 }
 
+#[cfg(feature = "coveralls")]
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
 pub struct Ci(pub CiService);
 
+#[cfg(feature = "coveralls")]
 impl FromStr for Ci {
     /// This can never fail, so the error type is uninhabited.
     type Err = std::convert::Infallible;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -10,6 +10,7 @@ use std::io::BufReader;
 use tracing::{error, info};
 
 pub mod cobertura;
+#[cfg(feature = "coveralls")]
 pub mod coveralls;
 pub mod html;
 pub mod json;
@@ -57,6 +58,7 @@ pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunErro
 }
 
 fn generate_requested_reports(config: &Config, result: &TraceMap) -> Result<(), RunError> {
+    #[cfg(feature = "coveralls")]
     if config.is_coveralls() {
         coveralls::export(result, config)?;
         info!("Coverage data sent");


### PR DESCRIPTION
This PR aims to make the coveralls api crate and git2 optional to avoid needing to pull in openssl unnecessarily.

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
