### PR TITLE
Remove HashMap println! in set_functions

### DIFF
--- a/src/traces.rs
+++ b/src/traces.rs
@@ -169,7 +169,6 @@ impl TraceMap {
     }
 
     pub fn set_functions(&mut self, functions: HashMap<PathBuf, Vec<Function>>) {
-        println!("{:?}", functions);
         self.functions = functions;
     }
 


### PR DESCRIPTION
This looks like a left-over debug `println!` but it's causing issues in [`cargo2junit`](https://github.com/johnterickson/cargo2junit) when using it together with `cargo-tarpaulin`:

```sh
RUSTC_BOOTSTRAP=1 cargo tarpaulin --out Xml --skip-clean --target-dir target-tarpaulin \
    -- -Z unstable-options --format json --report-time | cargo2junit > report.xml
```

`cargo-tarpaulin` is writing it's own report file, but the rustc output of `--format json` is also processed by `cargo2junit` at the same time (to avoid running `cargo test` twice).

`cargo2junit` is trying to detect rustc output by looking for lines starting with `{`, this is also the case for `std::fmt::Debug` of the HashMap (while not valid json), causing the `cargo2junit` parser the fail.

This patch solves this by removing the debug `println!`.