### PR TITLE
feat: try to get path to config-file from `CARGO_TARPAULIN_CONFIG_FILE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 From 2019 onwards, all notable changes to tarpaulin will be documented in this
 file.
 
+## [0.31.3] 2024-10-10
+### Added
+- The `CARGO_TARPAULIN_CONFIG_FILE` environment variable may be used to set the
+  path to the configuration file. The command line argument has precedence,
+  but this environment variable has precedence over `tarpaulin.toml` and `.tarpaulin.toml`.
+
 ## [0.31.2] 2024-08-20
 ### Changed
 - Removed debug printout of function map

--- a/README.md
+++ b/README.md
@@ -543,7 +543,8 @@ the seccomp policies for Docker.
 ### Config file
 
 Tarpaulin has a config file setting where multiple coverage setups can be
-encoded in a toml file. This can be provided by an argument or if a
+encoded in a toml file. This can be provided by an argument,
+by the environment variable `CARGO_TARPAULIN_CONFIG_FILE` or if a
 `.tarpaulin.toml` or `tarpaulin.toml` is present in the same directory as
 the projects manifest or in the root directory that will be used unless
 `--ignore-config` is passed. Below is an example file:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -522,7 +522,9 @@ impl Config {
 
     /// Taking an existing config look for any relevant config files
     pub fn check_for_configs(&self) -> Option<PathBuf> {
-        if let Some(root) = &self.root {
+        if let Some(config_file) = env::var_os("CARGO_TARPAULIN_CONFIG_FILE") {
+            Some(config_file.into())
+        } else if let Some(root) = &self.root {
             Self::check_path_for_configs(root)
         } else if let Some(root) = self.manifest.clone().parent() {
             Self::check_path_for_configs(root)


### PR DESCRIPTION
With this commit, tarpaulin will try to get the path to the configuration file (usually `tarpaulin.toml`) from the environment variable `CARGO_TARPAULIN_CONFIG_FILE` first, before proceeding with trying `tarpaulin.toml` and `.tarpaulin.toml`. The motivation of this PR is, that I have multiple repositories with the same tarpaulin-config. With https://direnv.net/, I am able to set environment variables, which would allow me to set `CARGO_TARPAULIN_CONFIG_FILE`, thus avoiding duplicate configurations. Symlinks are not really an option with repositories.