### PR TITLE
Added feature --include-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Options:
   -p, --packages [<PACKAGE>...]    Package id specifications for which package should be build. See cargo help pkgid for more info
   -e, --exclude [<PACKAGE>...]     Package id specifications to exclude from coverage. See cargo help pkgid for more info
       --exclude-files [<FILE>...]  Exclude given files from coverage results has * wildcard
+      --include-files [<FILE>...]  Include only given files in coverage results. Can have a * wildcard
   -t, --timeout <SECONDS>          Integer for the maximum time in seconds without response from test before timeout (default is 1 minute)
       --post-test-delay <SECONDS>  Delay after test to collect coverage profiles
       --follow-exec                Follow executed processes capturing coverage information if they're part of your project

--- a/src/args.rs
+++ b/src/args.rs
@@ -134,6 +134,9 @@ pub struct ConfigArgs {
     /// Exclude given files from coverage results has * wildcard
     #[arg(long, value_name = "FILE", num_args = 0..)]
     pub exclude_files: Vec<Pattern>,
+    /// Include only given files in coverage results. Can have a * wildcard
+    #[arg(long, value_name = "FILE", num_args = 0..)]
+    pub include_files: Vec<Pattern>,
     /// Integer for the maximum time in seconds without response from test before timeout (default is 1 minute).
     #[arg(long, short, value_name = "SECONDS")]
     pub timeout: Option<u64>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -852,8 +852,8 @@ impl Config {
         let project = self.strip_base_dir(path);
 
         //if empty, then parameter not used, thus all files are included by default
-        if self.included_files.borrow().len() == 0 {
-            return true
+        if self.included_files.borrow().is_empty() {
+            return true;
         }
 
         self.included_files

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,6 +127,12 @@ pub struct Config {
     /// Files to exclude from testing in uncompiled form (for serde)
     #[serde(rename = "exclude-files")]
     excluded_files_raw: Vec<String>,
+    /// Files to include in testing in their compiled form
+    #[serde(skip_deserializing, skip_serializing)]
+    included_files: RefCell<Vec<glob::Pattern>>,
+    /// Files to include in testing in uncompiled form (for serde)
+    #[serde(rename = "include-files")]
+    included_files_raw: Vec<String>,
     /// Varargs to be forwarded to the test executables.
     #[serde(rename = "args")]
     pub varargs: Vec<String>,
@@ -238,6 +244,8 @@ impl Default for Config {
             exclude: vec![],
             excluded_files: RefCell::new(vec![]),
             excluded_files_raw: vec![],
+            included_files: RefCell::new(vec![]),
+            included_files_raw: vec![],
             varargs: vec![],
             test_timeout: default_test_timeout(),
             release: false,
@@ -330,6 +338,8 @@ impl From<ConfigArgs> for ConfigWrapper {
             exclude: args.exclude,
             excluded_files_raw: args.exclude_files.iter().map(Pattern::to_string).collect(),
             excluded_files: RefCell::new(args.exclude_files),
+            included_files_raw: args.include_files.iter().map(Pattern::to_string).collect(),
+            included_files: RefCell::new(args.include_files),
             varargs: args.args,
             test_timeout: Duration::from_secs(args.timeout.unwrap_or(60)),
             release: args.release,
@@ -776,6 +786,15 @@ impl Config {
             let mut excluded_files = self.excluded_files.borrow_mut();
             excluded_files.clear();
         }
+
+        if !other.included_files_raw.is_empty() {
+            self.included_files_raw
+                .extend_from_slice(&other.included_files_raw);
+
+            // Now invalidated the compiled regex cache so clear it
+            let mut included_files = self.included_files.borrow_mut();
+            included_files.clear();
+        }
     }
 
     pub fn pick_optional_config<T: Clone>(
@@ -816,6 +835,28 @@ impl Config {
         let project = self.strip_base_dir(path);
 
         self.excluded_files
+            .borrow()
+            .iter()
+            .any(|x| x.matches_path(&project))
+    }
+
+    #[inline]
+    pub fn include_path(&self, path: &Path) -> bool {
+        if self.included_files.borrow().len() != self.included_files_raw.len() {
+            let mut included_files = self.included_files.borrow_mut();
+            let mut compiled = globs_from_excluded(&self.included_files_raw);
+            included_files.clear();
+            included_files.append(&mut compiled);
+        }
+
+        let project = self.strip_base_dir(path);
+
+        //if empty, then parameter not used, thus all files are included by default
+        if self.included_files.borrow().len() == 0 {
+            return true
+        }
+
+        self.included_files
             .borrow()
             .iter()
             .any(|x| x.matches_path(&project))
@@ -977,6 +1018,30 @@ mod tests {
     }
 
     #[test]
+    fn include_paths_directory_separators() {
+        let args = TarpaulinCli::parse_from(vec![
+            "tarpaulin",
+            "--include-files",
+            "src/foo/*",
+            "src\\bar\\*",
+        ]);
+        let conf = ConfigWrapper::from(args.config).0;
+        assert_eq!(conf.len(), 1);
+        assert!(conf[0].include_path(Path::new("src/foo/file.rs")));
+        assert!(conf[0].include_path(Path::new("src\\bar\\file.rs")));
+
+        cfg_if::cfg_if! {
+            if #[cfg(windows)] {
+                assert!(conf[0].include_path(Path::new("src\\foo\\file.rs")));
+                assert!(conf[0].include_path(Path::new("src/bar/file.rs")));
+            } else {
+                assert!(!conf[0].include_path(Path::new("src\\foo\\file.rs")));
+                assert!(!conf[0].include_path(Path::new("src/bar/file.rs")));
+            }
+        }
+    }
+
+    #[test]
     fn no_exclusions() {
         let args = TarpaulinCli::parse_from(vec!["tarpaulin"]);
         let conf = ConfigWrapper::from(args.config).0;
@@ -985,6 +1050,11 @@ mod tests {
         assert!(!conf[0].exclude_path(Path::new("src/mod.rs")));
         assert!(!conf[0].exclude_path(Path::new("unrelated.rs")));
         assert!(!conf[0].exclude_path(Path::new("module.rs")));
+
+        assert!(conf[0].include_path(Path::new("src/module/file.rs")));
+        assert!(conf[0].include_path(Path::new("src/mod.rs")));
+        assert!(conf[0].include_path(Path::new("unrelated.rs")));
+        assert!(conf[0].include_path(Path::new("module.rs")));
     }
 
     #[test]
@@ -996,6 +1066,17 @@ mod tests {
         assert!(!conf[0].exclude_path(Path::new("src/mod.rs")));
         assert!(!conf[0].exclude_path(Path::new("src/notlib.rs")));
         assert!(!conf[0].exclude_path(Path::new("lib.rs")));
+    }
+
+    #[test]
+    fn include_exact_file() {
+        let args = TarpaulinCli::parse_from(vec!["tarpaulin", "--include-files", "*/lib.rs"]);
+        let conf = ConfigWrapper::from(args.config).0;
+        assert_eq!(conf.len(), 1);
+        assert!(conf[0].include_path(Path::new("src/lib.rs")));
+        assert!(!conf[0].include_path(Path::new("src/mod.rs")));
+        assert!(!conf[0].include_path(Path::new("src/notlib.rs")));
+        assert!(!conf[0].include_path(Path::new("lib.rs")));
     }
 
     #[test]

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -94,6 +94,7 @@ pub fn get_source_walker(config: &Config) -> impl Iterator<Item = DirEntry> + '_
         .filter_entry(move |e| is_coverable_file_path(e.path(), &root, &target))
         .filter_map(Result::ok)
         .filter(move |e| !(config.exclude_path(e.path())))
+        .filter(move |e| (config.include_path(e.path())))
         .filter(is_source_file)
 }
 

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -94,7 +94,7 @@ pub fn get_source_walker(config: &Config) -> impl Iterator<Item = DirEntry> + '_
         .filter_entry(move |e| is_coverable_file_path(e.path(), &root, &target))
         .filter_map(Result::ok)
         .filter(move |e| !(config.exclude_path(e.path())))
-        .filter(move |e| (config.include_path(e.path())))
+        .filter(move |e| config.include_path(e.path()))
         .filter(is_source_file)
 }
 

--- a/src/test_loader.rs
+++ b/src/test_loader.rs
@@ -287,6 +287,7 @@ fn get_line_addresses<'data>(
                         config.include_tests() || !k.path.starts_with(project.join("tests"))
                     })
                     .filter(|(ref k, _)| !(config.exclude_path(&k.path)))
+                    .filter(|(ref k, _)| (config.include_path(&k.path)))
                     .filter(|(ref k, _)| {
                         !analysis.should_ignore(k.path.as_ref(), &(k.line as usize))
                     })
@@ -335,13 +336,20 @@ fn get_line_addresses<'data>(
         }
     }
 
+    let trace_analysis = add_line_analysis(analysis, config, &result);
+    result.merge(&trace_analysis);
+    Ok(result)
+}
+
+fn add_line_analysis(analysis: &HashMap<PathBuf, LineAnalysis>, config: &Config, input_trace: &TraceMap) -> TraceMap {
+    let mut result_trace = TraceMap::new();
     for (file, line_analysis) in analysis.iter() {
-        if config.exclude_path(file) {
+        if config.exclude_path(file) || !config.include_path(file) {
             continue;
         }
         for line in &line_analysis.cover {
             let line = *line as u64;
-            if !result.contains_location(file, line) && !line_analysis.should_ignore(line as usize)
+            if !input_trace.contains_location(file, line) && !line_analysis.should_ignore(line as usize)
             {
                 let rpath = config.strip_base_dir(file);
                 trace!(
@@ -349,11 +357,12 @@ fn get_line_addresses<'data>(
                     rpath.display(),
                     line
                 );
-                result.add_trace(file, Trace::new_stub(line));
+                result_trace.add_trace(file, Trace::new_stub(line));
             }
         }
     }
-    Ok(result)
+
+    result_trace
 }
 
 #[cfg(ptrace_supported)]

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -113,6 +113,9 @@ exclude = []
 # List of file paths to exclude from testing.
 exclude-files = []
 
+# List of file paths to include (and exclude all others) from testing.
+include-files = []
+
 # Additional arguments to pass to the test executables.
 args = []
 


### PR DESCRIPTION
Added the flag `--include-files` to tarpaulin to only have a select amount of files that we get coverage from. It can save some time, as we are not looking at the traces of excluded files.

A condition has been added in the include_path function to make sure that --include-files is deactivated when no argument has been passed: otherwise, this would exclude all files from the report (as --include-files excludes all files by default).

Pretty much copied from the `--exclude-files` feature. Added some tests to make sure everything was working fine.

Here are some commands that I tested on another Rust project from the built image:
cargo tarpaulin --include-files src/jwt/mod.rs --out xml --> SUCCESS only 5 lines seen, 60% coverage
cargo tarpaulin --include-files src/jwt/* --exclude-files src/utils/* --out xml --> SUCCESS only 5 lines seen, 60% coverage.
cargo tarpaulin --exclude-files src/utils/* --out xml --> SUCCESS 101 lines seen, 3% coverage