### PR TITLE
Fix toml

### DIFF
--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -99,9 +99,6 @@ pub fn execute(
     envar: &[(String, String)],
 ) -> Result<TestHandle, RunError> {
     let program = CString::new(test.display().to_string()).unwrap_or_default();
-    // Move inferior to a different process group than tarpaulin so signals etc applied to
-    // tarpaulin don't apply to our inferior process
-    setpgid(Pid::from_raw(0), Pid::from_raw(0));
     if is_aslr_enabled() {
         disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {e}")))?;
     }

--- a/src/process_handling/linux.rs
+++ b/src/process_handling/linux.rs
@@ -99,6 +99,9 @@ pub fn execute(
     envar: &[(String, String)],
 ) -> Result<TestHandle, RunError> {
     let program = CString::new(test.display().to_string()).unwrap_or_default();
+    // Move inferior to a different process group than tarpaulin so signals etc applied to
+    // tarpaulin don't apply to our inferior process
+    setpgid(Pid::from_raw(0), Pid::from_raw(0));
     if is_aslr_enabled() {
         disable_aslr().map_err(|e| RunError::TestRuntime(format!("ASLR disable failed: {e}")))?;
     }

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -98,14 +98,14 @@ target-dir = "./target"
 # Run the tests without accessing the network (offline mode).
 offline = false
 
-# Cargo subcommand to run; options are "test" or "build".
-command = "test"
+# Cargo subcommand to run; options are "Test" or "Build".
+command = "Test"
 
-# Types of tests to collect coverage for. For example: ["unit", "integration"]
-run-types = ["unit"]
+# Types of tests to collect coverage for. For example: ["Lib", "AllTargets", "Benchmarks", "Bins", "Examples", "Doctests", "Tests"]
+run-types = ["AllTargets"]
 
 # List of packages to include when building the target project.
-packages = ["my_package"]
+packages = []
 
 # List of packages to exclude from testing.
 exclude = []
@@ -156,7 +156,7 @@ no-fail-fast = false
 avoid-cfg-tarpaulin = false
 
 # Colouring of logs in the terminal output (e.g., "auto", "always", "never").
-color = "auto"
+color = "Auto"
 
 # Follow traced executables down through function calls.
 follow-exec = true


### PR DESCRIPTION
From building a debugger in rust noticed a nice little thing for a bit more separation of tarpaulin and the inferior test process.

But then it broke all the ptrace tests so back to the drawing board.