### PR TITLE
Move test threads to env var not CLI arg

### DIFF
--- a/src/process_handling/mod.rs
+++ b/src/process_handling/mod.rs
@@ -236,21 +236,14 @@ fn execute_test(
         argv.push("--color".to_string());
         argv.push(config.color.to_string().to_ascii_lowercase());
     }
-    let no_test_env = if let Ok(threads) = env::var("RUST_TEST_THREADS") {
+    if let Ok(threads) = env::var("RUST_TEST_THREADS") {
         envars.push(("RUST_TEST_THREADS".to_string(), threads));
-        false
-    } else {
-        true
-    };
-
-    if no_test_env
-        && test.is_test_type()
+    } else if test.is_test_type()
         && !config.implicit_test_threads
         && !config.varargs.iter().any(|x| x.contains("--test-threads"))
     {
         if let Some(threads) = num_threads {
-            argv.push("--test-threads".to_string());
-            argv.push(threads.to_string());
+            envars.push(("RUST_TEST_THREADS".to_string(), threads.to_string()));
         }
     }
 


### PR DESCRIPTION
#1621 and other past likely closed issues where people expected the args passed to the test binary were for their test and not to be consumed by cargo test should hopefully be fixed by this.