### PR TITLE
Handle doctests file paths that contain dashes

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -427,31 +427,26 @@ fn run_cargo(
 }
 
 fn convert_to_prefix(p: &Path) -> Option<String> {
-    // Need to go from directory after last one with Cargo.toml
-    let convert_name = |p: &Path| {
-        if let Some(s) = p.file_name() {
-            s.to_str().map(|x| x.replace(['.', '-'], "_")).unwrap_or_default()
-        } else {
-            String::new()
+    let mut buffer = vec![];
+    let mut p = Some(p);
+    while let Some(path_temp) = p {
+        // The only component of the path that should be lacking a filename is the final empty
+        // parent of a relative path, which we don't want to include anyway.
+        if let Some(name) = path_temp.file_name().and_then(|s| s.to_str()) {
+            buffer.push(name.replace(['.', '-'], "_"));
         }
-    };
-    let mut buffer = vec![convert_name(p)];
-    let mut parent = p.parent();
-    while let Some(path_temp) = parent {
-        buffer.insert(0, convert_name(path_temp));
-        parent = path_temp.parent();
+        p = path_temp.parent();
     }
     if buffer.is_empty() {
         None
     } else {
+        buffer.reverse();
         Some(buffer.join("_"))
     }
 }
 
 fn is_prefix_match(prefix: &str, entry: &Path) -> bool {
-    convert_to_prefix(entry)
-        .map(|s| s.contains(prefix))
-        .unwrap_or(false)
+    convert_to_prefix(entry).as_deref() == Some(prefix)
 }
 
 /// This returns a map of the string prefixes for the file in the doc test and a list of lines

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -430,7 +430,7 @@ fn convert_to_prefix(p: &Path) -> Option<String> {
     // Need to go from directory after last one with Cargo.toml
     let convert_name = |p: &Path| {
         if let Some(s) = p.file_name() {
-            s.to_str().map(|x| x.replace('.', "_")).unwrap_or_default()
+            s.to_str().map(|x| x.replace(['.', '-'], "_")).unwrap_or_default()
         } else {
             String::new()
         }

--- a/tests/data/doctest_workspace_should_panic/Cargo.toml
+++ b/tests/data/doctest_workspace_should_panic/Cargo.toml
@@ -2,5 +2,6 @@
 
 members = [
     "foo",
-    "bar"
+    "bar",
+    "foo-bar",
 ]

--- a/tests/data/doctest_workspace_should_panic/foo-bar/Cargo.toml
+++ b/tests/data/doctest_workspace_should_panic/foo-bar/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "foo-bar"
+version = "0.1.0"
+authors = ["xd009642 <danielmckenna93@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/data/doctest_workspace_should_panic/foo-bar/src/lib.rs
+++ b/tests/data/doctest_workspace_should_panic/foo-bar/src/lib.rs
@@ -1,0 +1,15 @@
+/// ```
+/// use foo_bar::foo1;
+/// foo1();
+/// ```
+pub fn foo1() {
+}
+
+
+/// ```should_panic
+/// use foo_bar::bar1;
+/// bar1();
+/// ```
+pub fn bar1() {
+    panic!()
+}


### PR DESCRIPTION
When trying out the doctest support on a workspace involving many `kebab-case` named crates I noticed any `should_panic` doctests were failing.

I didn't manage to run the tests to confirm the added test reproduces it properly, I'm getting crashes inside the test runner on `develop` too. I'll spend a little more time tomorrow trying to diagnose what about my weird setup the test runner doesn't like.