### PR TITLE
Move reports to project root.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file.
 
 ## [Unreleased]
 ### Changed
-- Made HTML report writing consistent with the rest of the reports - `$TARGET_DIR/tarpaulin/` by default
+- Made all reports consistent and put them in the project root by default
 
 ## [0.32.8] 2025-06-23
 ### Changed

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -513,7 +513,7 @@ impl Config {
                 path.clone()
             }
         } else {
-            self.target_dir().join("tarpaulin")
+            self.root()
         };
         fix_unc_path(&path)
     }
@@ -1322,10 +1322,7 @@ mod tests {
 
         let mut neither_merged_dir = no_dir.clone();
         neither_merged_dir.merge(&no_dir);
-        assert_eq!(
-            neither_merged_dir.output_dir(),
-            no_dir.target_dir().join("tarpaulin")
-        );
+        assert_eq!(neither_merged_dir.output_dir(), env::current_dir().unwrap(),);
 
         let mut both_merged_dir = has_dir;
         both_merged_dir.merge(&other_dir);

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -37,10 +37,12 @@ fn coverage_report_name(config: &Config) -> String {
 pub fn report_coverage(config: &Config, result: &TraceMap) -> Result<(), RunError> {
     if !result.is_empty() {
         generate_requested_reports(config, result)?;
-        let mut report_dir = config.output_dir();
+        let report_dir = config.output_dir();
         if !report_dir.exists() {
             let _ = create_dir_all(&report_dir);
         }
+
+        let mut report_dir = config.target_dir().join("tarpaulin");
         report_dir.push(coverage_report_name(config));
         let file = File::create(&report_dir)
             .map_err(|_| RunError::CovReport("Failed to create run report".to_string()))?;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -569,7 +569,7 @@ fn sanitised_paths() {
             }
         }
     }
-    assert_eq!(count, 5);
+    assert_eq!(count, 4);
 }
 
 #[test]
@@ -603,7 +603,6 @@ fn output_dir_workspace() {
     }
     println!("{:?}", output);
     assert!(output.remove("cobertura.xml"));
-    assert!(output.remove("coverage.json"));
     assert!(output.remove("lcov.info"));
     assert!(output.remove("tarpaulin-report.html"));
     assert!(output.remove("tarpaulin-report.json"));


### PR DESCRIPTION
This stops things like cobertura breaking

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
