### PR TITLE
Add explicit lifetime annotations to return types

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -473,7 +473,7 @@ impl Config {
         result
     }
 
-    pub(crate) fn get_metadata(&self) -> Ref<Option<Metadata>> {
+    pub(crate) fn get_metadata(&self) -> Ref<'_, Option<Metadata>> {
         if self.metadata.borrow().is_none() {
             match MetadataCommand::new().manifest_path(&self.manifest).exec() {
                 Ok(meta) => {

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -178,7 +178,7 @@ impl TraceMap {
     }
 
     /// Provides an iterator to the underlying map of PathBufs to Vec<Trace>
-    pub fn iter(&self) -> Iter<PathBuf, Vec<Trace>> {
+    pub fn iter(&self) -> Iter<'_, PathBuf, Vec<Trace>> {
         self.traces.iter()
     }
 


### PR DESCRIPTION
Add explicit lifetime parameters to get_metadata() and iter() return types to comply with Rust lifetime elision requirements.

Fix the compilation warnings in the latest stable Rust version 1.89.0 .

> [Add a warn-by-default mismatched_lifetime_syntaxes lint.](https://github.com/rust-lang/rust/pull/138677) This lint detects when the same lifetime is referred to by different syntax categories between function arguments and return values, which can be confusing to read, especially in unsafe code. This lint supersedes the warn-by-default elided_named_lifetimes lint.

<img width="863" height="732" alt="image" src="https://github.com/user-attachments/assets/04ded97a-6f54-4c1d-906a-da0f8ca77bd9" />

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
