### PR TITLE
Minor readme edit: uncomment CODECOV_TOKEN as it is required now

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ jobs:
           cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true


### PR DESCRIPTION
Minor readme edit of outdated information

If you open the codecov app you get a notification that you now have to use tokens to upload coverage reports.

In the settings you can disable this for public repos but the default is required, so this comment in the docs is no longer true.

<img width="2843" height="744" alt="image" src="https://github.com/user-attachments/assets/18945740-dd9f-4296-b464-654afbec41d9" />

The learn more link brings you here: https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token

> # Uploading without a token
> Codecov does not require a token for an upload when either of the following conditions are true:
> 
> - the repository is public and the organization has disabled token authentication for public repositories
>
> or
> 
> - the repository is public and the upload is for a commit that is on an "unprotected" branch (like forkname:main)