### PR TITLE
#1791: Add line count to HTML output

### DIFF
--- a/src/report/report_viewer.css
+++ b/src/report/report_viewer.css
@@ -126,9 +126,13 @@ body {
 }
 .code-line {
   margin: 0;
-  padding: 0.3em;
   height: 1em;
   counter-increment: line;
+
+  position: absolute;
+  padding: 0 0.3em 0.3em 0.3em;
+  display: inherit;
+  width: 100%;
 }
 .code-line_covered {
   background: var(--green);
@@ -137,16 +141,44 @@ body {
   background: var(--red);
 }
 
-.stat-line-hit {
+.code-text-container {
+  position: relative;
+  height: 1em;
+  padding: 0.3em 0;
+}
+
+.cover-indicator {
+  display: flex;
+  width: 100%;
   position: absolute;
-  display: inline;
-  transform: translateX(-64px);
-  border: 1px solid black;
-  border-radius: 8px;
-  padding: 0 4px;
-  background-color: var(--yellow);
+  justify-content: end;
+  height: 1em;
+  align-items: center;
+  padding: 0 0.3em 0.3em 0.3em;
+}
+
+.cover-indicator.check-cover::after {
+  content: "\2713";
+  font-weight: bold;
+  background-color: var(--green);
+  height: 1em;
+}
+
+.cover-indicator.no-cover::after {
+  content: "\2716";
+  font-weight: bold;
+  background-color: var(--red);
+  height: 1em;
+}
+
+.stat-line-hit {
   max-width: 48px;
   overflow: hidden;
+  font-weight: bold;
+  margin-right: 4px;
+  background-color: var(--green);
+  position: relative;
+  top: 0.1em;
 }
 
 #theme-toggle-label {

--- a/src/report/report_viewer.js
+++ b/src/report/report_viewer.js
@@ -243,19 +243,24 @@ function FileContent({file}) {
       const uncovered = trace && !trace.stats.Line;
       const nbHit = covered? trace.stats.Line: 0;
       return e(
-        'code',
-        {
-          className: 'code-line' + (covered ? ' code-line_covered' : '') + (uncovered ? ' code-line_uncovered' : ''),
-        },
-        covered? e(
-          'div',
-          { 
-            className: 'stat-line-hit',
-            title: "Line hit: " + nbHit + " times"
+        'div',
+        { className: 'code-text-container' },
+        e(
+          'code',
+          {
+            className: 'code-line' + (covered ? ' code-line_covered' : '') + (uncovered ? ' code-line_uncovered' : ''),
           },
-          "Hit:" + nbHit
-        ): null,
-        line,
+          line
+        ),
+        e(
+          'div',
+          { className: 'cover-indicator' + (covered? ' check-cover': '') + (uncovered? ' no-cover': '')},
+          e(
+            'div',
+            { className: (covered? 'stat-line-hit': '')},
+            covered? nbHit: ""
+          )
+        )
       );
     }),
   );


### PR DESCRIPTION
Removed tooltip for the covered line that was indicating the number of hits for the line.

Instead, replaced it by a small indicator at the right of the line number clearly indicating "Hit:<number>".

On hover, a tooltip appears that indicates the full number if it could not be fully visible from the limited space (useful when the value is above 999) and to provide more context
