### PR TITLE
Fix sub-module path resolution for lib.rs/main.rs/mod.rs

### DIFF
--- a/src/source_analysis/items.rs
+++ b/src/source_analysis/items.rs
@@ -81,8 +81,8 @@ impl SourceAnalysis {
         let _guard = ctx.push_to_symbol_stack(module.ident.to_string());
         let analysis = self.get_line_analysis(ctx.file.to_path_buf());
         analysis.ignore_tokens(module.mod_token);
-        let check_insides = self.check_attr_list(&module.attrs, ctx);
-        if check_insides {
+        let should_cover = self.check_attr_list(&module.attrs, ctx);
+        if should_cover {
             if let Some((_, ref items)) = module.content {
                 self.process_items(items, ctx);
             }
@@ -94,14 +94,25 @@ impl SourceAnalysis {
                     self.ignore_nested_modules(items, ctx);
                 }
             } else {
-                // Get the file or directory name of the module
+                // This item was determined not to be covered, so we ignore it.
+                // Do a best-effort calculation of the path of the module
+                // corresponding to the mod item to ignore it.
+
+                // Get the file or directory name of the module containing the mod item
                 let mut p = if let Some(parent) = ctx.file.parent() {
                     parent.to_path_buf()
                 } else {
                     PathBuf::new()
                 };
-                if let Some(s) = ctx.file.file_stem().and_then(|x| x.to_str()) {
-                    p.push(s);
+                match ctx.file.file_stem().and_then(|x| x.to_str()) {
+                    Some(name) if ["lib", "mod", "main"].contains(&name) => {
+                        // skip because these segments are transparent in module tree
+                    }
+                    Some(name) => p.push(name),
+                    None => warn!(
+                        "Could not read file stem of {:?}; sub-module path may be wrong",
+                        ctx.file
+                    ),
                 }
                 let stack = ctx.symbol_stack.borrow();
                 for s in stack.iter().take(stack.len() - 1) {

--- a/src/source_analysis/tests.rs
+++ b/src/source_analysis/tests.rs
@@ -1844,6 +1844,63 @@ fn module_nesting_correct() {
         .ignore_mods
         .borrow()
         .contains(&PathBuf::from("src/foo/bar/inner.rs")));
+
+    // Top-level `#[cfg(test)] mod foo;` in lib.rs must resolve to src/foo.rs,
+    // not src/lib/foo.rs. Same for mod.rs and main.rs — all three file stems
+    // are transparent in the module tree.
+    let ctx = Context {
+        config: &config,
+        file_contents: "
+        #[cfg(test)]
+        mod tests;
+        ",
+        file: Path::new("src/lib.rs"),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    assert!(ctx
+        .ignore_mods
+        .borrow()
+        .contains(&PathBuf::from("src/tests.rs")));
+
+    let ctx = Context {
+        config: &config,
+        file_contents: "
+        #[cfg(test)]
+        mod tests;
+        ",
+        file: Path::new("src/sub/mod.rs"),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    assert!(ctx
+        .ignore_mods
+        .borrow()
+        .contains(&PathBuf::from("src/sub/tests.rs")));
+
+    let ctx = Context {
+        config: &config,
+        file_contents: "
+        #[cfg(test)]
+        mod tests;
+        ",
+        file: Path::new("src/main.rs"),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    assert!(ctx
+        .ignore_mods
+        .borrow()
+        .contains(&PathBuf::from("src/tests.rs")));
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/xd009642/tarpaulin/issues/1837

Problem: In the source code analysis phase, `visit_mod` appended the enclosing file's stem to the child module path when determining where the module should live on disk, so `#[cfg(test)] mod tests;` in `lib.rs` resolved to `src/lib/tests.rs` instead of `src/tests.rs`. The bogus path never matched the source walker, so the child file escaped the ignore filter and its non-#[test] items were reported as uncovered, as reported in the issue above.

Fix: Skip the stem when the enclosing file is a crate root (lib.rs, main.rs) or directory module (mod.rs); those are transparent in Rust's module tree. Apparently, `ignore_nested_modules` already had the lib/mod guard but `visit_mod` did not. Btw. ignoring `main.rs` was missing from both, but I left `ignore_nested_modules` changes out of scope, as it wasn't relevant for this exact fix. A similar pattern was also found in `src/source_analysis/mod.rs:428` (Might be better to check if those warrant changes too?)

I also added some comments and renamed some local variables, to reflect my understanding of the code.

I think this targeted fix manages to fix the issue linked above, but I have some concerns about the codebase based on these short explorations: the module resolution is basically replicating what Cargo and rustc are doing already, and it would be much better to delegate those parts, if possible. I don't know how feasible that would be, though, so just a note.

Disclaimer: I used Claude Code Opus 4.7 to explore the causes of the bug and have suggestions for the fixes. The code in the actual fix in `src/source_analysis/items.rs` is fully mine. However, the test code in `src/source_analysis/tests.rs` is generated by Claude and reviewed by me.