### PR TITLE
Fix false-negative on inert match arms in generics

### DIFF
--- a/src/source_analysis/expressions.rs
+++ b/src/source_analysis/expressions.rs
@@ -134,7 +134,7 @@ impl SourceAnalysis {
     fn visit_match(&mut self, mat: &ExprMatch, ctx: &Context) -> SubResult {
         // a match with some arms is unreachable iff all its arms are unreachable
         let mut result = None;
-        for arm in &mat.arms {
+        for (arm_idx, arm) in mat.arms.iter().enumerate() {
             if self.check_attr_list(&arm.attrs, ctx) {
                 let reachable = self.process_expr(&arm.body, ctx);
                 if reachable.is_reachable() {
@@ -145,6 +145,7 @@ impl SourceAnalysis {
                     }
                     result = result.map(|x| x + reachable).or(Some(reachable));
                 }
+                self.maybe_ignore_inert_match_arm(arm, arm_idx, &mat.arms, ctx);
             } else {
                 let analysis = self.get_line_analysis(ctx.file.to_path_buf());
                 analysis.ignore_tokens(arm);
@@ -157,6 +158,56 @@ impl SourceAnalysis {
             analysis.ignore_tokens(mat);
             SubResult::Unreachable
         }
+    }
+
+    // LLVM doesn't always assign a coverage region to match arm patterns that are
+    // inert (i.e., static patterns that don't bind any names).
+    // In force-covered functions, this leads them to be reported as uncovered,
+    // so we mark such patterns as ignored. Bindings (`a =>`, `Some(x) =>`) and
+    // pattern guards do get a region, so they're left alone.
+    fn maybe_ignore_inert_match_arm(
+        &mut self,
+        arm: &Arm,
+        arm_idx: usize,
+        all_arms: &[Arm],
+        ctx: &Context,
+    ) {
+        if !pattern_is_inert(&arm.pat) {
+            return;
+        }
+        let pat_line = arm.pat.span().start().line;
+        let end_line = match &arm.guard {
+            Some((_, guard)) => guard.span().start().line,
+            None => {
+                let Expr::Block(b) = &*arm.body else {
+                    return;
+                };
+                let Some(first_stmt) = b.block.stmts.first() else {
+                    return;
+                };
+                first_stmt.span().start().line
+            }
+        };
+        if end_line <= pat_line {
+            return;
+        }
+        // Bail out if any sibling arm has content in the range we'd ignore —
+        // swallowing those rows would hide a sibling's coverage.
+        for (i, other) in all_arms.iter().enumerate() {
+            if i == arm_idx {
+                continue;
+            }
+            let s = other.pat.span().start().line;
+            let e = other.body.span().end().line;
+            if s < end_line && e >= pat_line {
+                return;
+            }
+        }
+        let analysis = self.get_line_analysis(ctx.file.to_path_buf());
+        if !analysis.is_force_covered(pat_line) {
+            return;
+        }
+        analysis.add_to_ignore(pat_line..end_line);
     }
 
     fn visit_if(&mut self, if_block: &ExprIf, ctx: &Context) -> SubResult {
@@ -324,6 +375,61 @@ impl SourceAnalysis {
         SubResult::Ok
     }
 }
+
+// A pattern is "inert" when matching it binds no name, i.e. it contains
+// only literals, existing idents, consts and passive syntactic structures.
+//
+// `Pat::Ident` is treated as a binding even for bare unit variants like
+// `None` — syn can't distinguish those from fresh bindings without name
+// resolution. The cost is a remaining false-negative for unit-variant arms;
+// the benefit is no false-positives from misidentifying a binding.
+fn pattern_is_inert(pat: &Pat) -> bool {
+    match pat {
+        Pat::Wild(_)
+        | Pat::Lit(_)
+        | Pat::Path(_)
+        | Pat::Const(_)
+        | Pat::Range(_)
+        | Pat::Rest(_) => true,
+        Pat::Or(o) => or_pattern_is_inert(o),
+        Pat::Paren(p) => pattern_is_inert(&p.pat),
+        Pat::Tuple(t) => t.elems.iter().all(pattern_is_inert),
+        Pat::TupleStruct(ts) => ts.elems.iter().all(pattern_is_inert),
+        Pat::Struct(s) => s.fields.iter().all(|f| pattern_is_inert(&f.pat)),
+        Pat::Reference(r) => pattern_is_inert(&r.pat),
+        Pat::Slice(s) => s.elems.iter().all(pattern_is_inert),
+        _ => false,
+    }
+}
+
+// Determine if an OR-pattern is inert by checking that all the alternatives
+// are inert. Special case: if some top-level alternatives are ident, the
+// pattern can usually be safely deduced to be inert even without name resolution,
+// which is usually required with idents. (Why? Because in case of a name-binding
+// OR-pattern, all the cases have to bind the same name; if this is not the case,
+// we can exclude the possibility of name binding.)
+fn or_pattern_is_inert(o: &PatOr) -> bool {
+    let ident_cases: Vec<&Ident> = o
+        .cases
+        .iter()
+        .filter_map(|c| match c {
+            Pat::Ident(i) if i.subpat.is_none() => Some(&i.ident),
+            _ => None,
+        })
+        .collect();
+    let uniform_binding =
+        ident_cases.len() == o.cases.len() && ident_cases.windows(2).all(|w| w[0] == w[1]);
+    if uniform_binding {
+        return false; // The degenerate non-inert ident bindings pattern
+    }
+
+    // The general case: check each alternative
+    o.cases.iter().all(|c| match c {
+        Pat::Ident(_) => true,
+        other => pattern_is_inert(other),
+    })
+}
+
 fn get_coverable_args(args: &Punctuated<Expr, Comma>) -> HashSet<usize> {
     let mut lines: HashSet<usize> = HashSet::new();
     for a in args.iter() {

--- a/src/source_analysis/expressions.rs
+++ b/src/source_analysis/expressions.rs
@@ -379,10 +379,12 @@ impl SourceAnalysis {
 // A pattern is "inert" when matching it binds no name, i.e. it contains
 // only literals, existing idents, consts and passive syntactic structures.
 //
-// `Pat::Ident` is treated as a binding even for bare unit variants like
-// `None` — syn can't distinguish those from fresh bindings without name
-// resolution. The cost is a remaining false-negative for unit-variant arms;
-// the benefit is no false-positives from misidentifying a binding.
+// Syn can't distinguish `Pat::Ident` bindings from unit variants or constants
+// without name resolution. Use Rust's naming convention as a heuristic:
+// idents starting with uppercase are paths (types, variants, or
+// SCREAMING_SNAKE constants) and are treated as inert. Lowercase idents are
+// treated as bindings. The `non_snake_case` lint keeps the false-positive
+// risk negligible.
 fn pattern_is_inert(pat: &Pat) -> bool {
     match pat {
         Pat::Wild(_)
@@ -391,43 +393,27 @@ fn pattern_is_inert(pat: &Pat) -> bool {
         | Pat::Const(_)
         | Pat::Range(_)
         | Pat::Rest(_) => true,
-        Pat::Or(o) => or_pattern_is_inert(o),
+        Pat::Or(o) => o.cases.iter().all(pattern_is_inert),
         Pat::Paren(p) => pattern_is_inert(&p.pat),
         Pat::Tuple(t) => t.elems.iter().all(pattern_is_inert),
         Pat::TupleStruct(ts) => ts.elems.iter().all(pattern_is_inert),
         Pat::Struct(s) => s.fields.iter().all(|f| pattern_is_inert(&f.pat)),
         Pat::Reference(r) => pattern_is_inert(&r.pat),
         Pat::Slice(s) => s.elems.iter().all(pattern_is_inert),
+        Pat::Ident(i) => pat_ident_is_path_by_convention(i),
         _ => false,
     }
 }
 
-// Determine if an OR-pattern is inert by checking that all the alternatives
-// are inert. Special case: if some top-level alternatives are ident, the
-// pattern can usually be safely deduced to be inert even without name resolution,
-// which is usually required with idents. (Why? Because in case of a name-binding
-// OR-pattern, all the cases have to bind the same name; if this is not the case,
-// we can exclude the possibility of name binding.)
-fn or_pattern_is_inert(o: &PatOr) -> bool {
-    let ident_cases: Vec<&Ident> = o
-        .cases
-        .iter()
-        .filter_map(|c| match c {
-            Pat::Ident(i) if i.subpat.is_none() => Some(&i.ident),
-            _ => None,
-        })
-        .collect();
-    let uniform_binding =
-        ident_cases.len() == o.cases.len() && ident_cases.windows(2).all(|w| w[0] == w[1]);
-    if uniform_binding {
-        return false; // The degenerate non-inert ident bindings pattern
-    }
-
-    // The general case: check each alternative
-    o.cases.iter().all(|c| match c {
-        Pat::Ident(_) => true,
-        other => pattern_is_inert(other),
-    })
+fn pat_ident_is_path_by_convention(i: &PatIdent) -> bool {
+    i.by_ref.is_none()
+        && i.mutability.is_none()
+        && i.subpat.is_none()
+        && i.ident
+            .to_string()
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_uppercase())
 }
 
 fn get_coverable_args(args: &Punctuated<Expr, Comma>) -> HashSet<usize> {

--- a/src/source_analysis/mod.rs
+++ b/src/source_analysis/mod.rs
@@ -272,6 +272,12 @@ impl LineAnalysis {
             || (self.max_line > 0 && self.max_line < line)
     }
 
+    /// Returns true iff `line` is in the force-cover set populated by
+    /// `cover_span` (generic, `#[inline]`, or generic impl method bodies).
+    pub fn is_force_covered(&self, line: usize) -> bool {
+        self.cover.contains(&line)
+    }
+
     /// Adds a line to the list of lines to ignore
     fn add_to_ignore(&mut self, lines: impl IntoIterator<Item = usize>) {
         if !self.ignore.contains(&Lines::All) {

--- a/src/source_analysis/tests.rs
+++ b/src/source_analysis/tests.rs
@@ -277,11 +277,39 @@ fn match_arm_block_brace_ignored_tuple_struct_inert() {
     // `Some(_)` — inert, must be ignored.
     assert!(lines.should_ignore(3));
     assert!(!lines.is_force_covered(3));
-    // `None` parses as Pat::Ident in syn — indistinguishable from a binding
-    // without type resolution, so conservatively treat it as NOT inert. If
-    // a future implementation disambiguates via uppercase-start heuristics
-    // or type info, flip this assertion.
-    assert!(!lines.should_ignore(6));
+    // `None` parses as Pat::Ident in syn. The uppercase-start heuristic
+    // classifies it as a path (unit variant), so the arm is inert.
+    assert!(lines.should_ignore(6));
+    assert!(!lines.is_force_covered(6));
+}
+
+#[test]
+fn match_arm_block_brace_ignored_screaming_snake_const() {
+    // `OP_TEXT` parses as Pat::Ident in syn. The uppercase-start heuristic
+    // classifies it as a path (constant), so the arm is inert.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "const OP_TEXT: u8 = 1;
+fn foo<S>(n: u8) -> bool {
+    match n {
+        OP_TEXT => {
+            true
+        }
+        _ => false,
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    assert!(lines.should_ignore(4));
+    assert!(!lines.is_force_covered(4));
 }
 
 #[test]

--- a/src/source_analysis/tests.rs
+++ b/src/source_analysis/tests.rs
@@ -89,6 +89,440 @@ fn match_pattern_logical_lines() {
     assert_ne!(lines.logical_lines.get(&8), Some(&3));
 }
 
+// Rule under test: the opening brace line of a match arm's block body
+// (`pat => {` where the body starts on a later line) must be ignored iff the
+// pattern is inert — no name binding, no guard, and no other arm sharing that
+// line. Inert patterns (wildcard, literal, or-of-literals, tuple-struct of
+// wildcards, ...) produce no MIR instruction anchored to the brace, so LLVM
+// emits no coverage region there; without the ignore, force-covered generic
+// fns report the brace line as uncovered.
+
+#[test]
+fn match_arm_block_brace_ignored_literal_pattern() {
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>() -> bool {
+    match true {
+        true => {
+            true
+        }
+        false => {
+            false
+        },
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // L3: `true => {`, L6: `false => {` — both must be ignored & not covered.
+    assert!(lines.should_ignore(3));
+    assert!(!lines.is_force_covered(3));
+    assert!(lines.should_ignore(6));
+    assert!(!lines.is_force_covered(6));
+    // Arm bodies must remain covered.
+    assert!(!lines.should_ignore(4));
+    assert!(!lines.should_ignore(7));
+}
+
+#[test]
+fn match_arm_block_brace_ignored_wildcard() {
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>() -> bool {
+    match true {
+        _ => {
+            true
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    assert!(lines.should_ignore(3));
+    assert!(!lines.is_force_covered(3));
+    assert!(!lines.should_ignore(4));
+}
+
+#[test]
+fn match_arm_block_brace_ignored_or_pattern_of_literals() {
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(n: u32) -> u32 {
+    match n {
+        1 | 2 | 3 => {
+            10
+        }
+        _ => {
+            0
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    assert!(lines.should_ignore(3));
+    assert!(!lines.is_force_covered(3));
+    assert!(lines.should_ignore(6));
+    assert!(!lines.is_force_covered(6));
+}
+
+#[test]
+fn match_arm_block_brace_ignored_or_pattern_of_differing_idents() {
+    // `OP_TEXT | OP_BINARY` — two Pat::Ident with different names. An
+    // or-pattern requires every alternative to bind the same set of names,
+    // so the differing names rule them both out as bindings — they must be
+    // constants or unit variants (inert). The fix treats the arm as inert
+    // without needing type resolution.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "const OP_TEXT: u8 = 1;
+const OP_BINARY: u8 = 2;
+fn foo<S>(n: u8) -> bool {
+    match n {
+        OP_TEXT | OP_BINARY => {
+            true
+        }
+        _ => false,
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // L5: `OP_TEXT | OP_BINARY => {` — must be ignored.
+    assert!(lines.should_ignore(5));
+    assert!(!lines.is_force_covered(5));
+}
+
+#[test]
+fn match_arm_brace_not_ignored_same_name_or_pattern() {
+    // `x | x` is a uniform single-name or-pattern — syntactically could be a
+    // binding, so conservative treatment applies (not inert). Pathological
+    // but well-defined; the fix must NOT ignore it.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(x: u32) -> u32 {
+    match x {
+        x | x => {
+            x
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    assert!(!lines.should_ignore(3));
+}
+
+#[test]
+fn match_arm_block_brace_ignored_tuple_struct_inert() {
+    // `Some(_)` binds nothing — inert. Same pattern MIR-wise as `_`: no
+    // StorageLive on a binding, so no region anchored to the brace.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(o: Option<u32>) -> u32 {
+    match o {
+        Some(_) => {
+            1
+        }
+        None => {
+            0
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // `Some(_)` — inert, must be ignored.
+    assert!(lines.should_ignore(3));
+    assert!(!lines.is_force_covered(3));
+    // `None` parses as Pat::Ident in syn — indistinguishable from a binding
+    // without type resolution, so conservatively treat it as NOT inert. If
+    // a future implementation disambiguates via uppercase-start heuristics
+    // or type info, flip this assertion.
+    assert!(!lines.should_ignore(6));
+}
+
+#[test]
+fn match_arm_brace_same_line_as_body_not_ignored() {
+    // `_ => { body }` on one line — brace line is also statement line, so the
+    // `fs > brace_line` guard in the fix must prevent ignoring it.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>() -> bool {
+    match true {
+        _ => { true }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    assert!(!lines.should_ignore(3));
+}
+
+#[test]
+fn match_arm_brace_not_ignored_with_binding() {
+    // `a =>` — binding introduces StorageLive/Dead pair anchored to the arm's
+    // scope; LLVM emits a region on the brace line naturally. Ignoring would
+    // suppress a real signal, so the fix must leave binding arms alone.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(x: bool) -> bool {
+    match x {
+        a => {
+            a
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    assert!(!lines.should_ignore(3));
+}
+
+#[test]
+fn match_arm_brace_not_ignored_with_binding_in_tuple_struct() {
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(o: Option<u32>) -> u32 {
+    match o {
+        Some(x) => {
+            x
+        }
+        None => {
+            0
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // `Some(x)` binds x — not inert.
+    assert!(!lines.should_ignore(3));
+}
+
+#[test]
+fn match_arm_brace_not_ignored_with_guard() {
+    // Guard expression has its own coverage probe and executes unconditionally
+    // for matching arms; the brace line is part of that execution path.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(x: u32) -> u32 {
+    match x {
+        _ if x > 0 => {
+            1
+        }
+        _ => {
+            0
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // Guarded arm on L3 — must not be ignored.
+    assert!(!lines.should_ignore(3));
+    // Second arm (no guard, inert) — still ignored.
+    assert!(lines.should_ignore(6));
+}
+
+#[test]
+fn match_arm_brace_not_ignored_shared_row() {
+    // Sibling arm with a non-block body sits on the same row as the next
+    // arm's opening brace. That row carries executable content from the
+    // sibling; ignoring it would lose the sibling's coverage signal.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(n: u32) -> u32 {
+    match n {
+        1 => 10, _ => {
+            0
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // L3 holds `1 => 10, _ => {` — the `1 => 10,` tail expression is
+    // executable content, so the row must not be ignored.
+    assert!(!lines.should_ignore(3));
+}
+
+#[test]
+fn match_arm_brace_not_ignored_in_monomorphic_fn() {
+    // Same inert pattern as `match_arm_block_brace_ignored_wildcard`, but the
+    // enclosing fn is not generic → not force-covered → LLVM emits a region
+    // on the brace line normally, so the fix must NOT ignore it.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo() -> bool {
+    match true {
+        _ => {
+            true
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    assert!(!lines.should_ignore(3));
+}
+
+#[test]
+fn match_arm_header_ignored_when_split_across_lines() {
+    // Unusual but legal: pattern, `=>`, and `{` each on their own line.
+    // LLVM only anchors a region to the body's first statement, so every
+    // row of the arm header (pattern + arrow + brace) misses force-cover
+    // and must be ignored, not just the brace row.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>() -> bool {
+    match true {
+        _
+        =>
+        {
+            true
+        }
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // L3 `_` and L4 `=>` — must be ignored via the header-range fix.
+    assert!(lines.should_ignore(3));
+    assert!(!lines.is_force_covered(3));
+    assert!(lines.should_ignore(4));
+    assert!(!lines.is_force_covered(4));
+    // L5 `{` — ignored by find_ignorable_lines anyway; checked for consistency.
+    assert!(lines.should_ignore(5));
+    // L6 `true` — body content, must remain coverable.
+    assert!(!lines.should_ignore(6));
+}
+
+#[test]
+fn match_arm_header_ignored_before_split_guard() {
+    // Guarded inert arm with pattern on its own line and `if cond` on the
+    // next. The guard expression carries its own coverage region, but the
+    // pattern row does not; ignore only the rows up to (not including) the
+    // guard.
+    let config = Config::default();
+    let ctx = Context {
+        config: &config,
+        file_contents: "fn foo<S>(x: u32) -> u32 {
+    match x {
+        _
+        if x > 0 => {
+            1
+        }
+        _ => 0,
+    }
+}",
+        file: Path::new(""),
+        ignore_mods: RefCell::new(HashSet::new()),
+        symbol_stack: RefCell::new(Vec::new()),
+    };
+
+    let parser = parse_file(ctx.file_contents).unwrap();
+    let mut analysis = SourceAnalysis::new();
+    analysis.process_items(&parser.items, &ctx);
+    let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
+    // L3 `_` — pattern on its own row, ignored.
+    assert!(lines.should_ignore(3));
+    assert!(!lines.is_force_covered(3));
+    // L4 `if x > 0 => {` — guard row, coverable via its region.
+    assert!(!lines.should_ignore(4));
+}
+
 #[test]
 fn line_analysis_works() {
     let mut la = LineAnalysis::new();
@@ -785,8 +1219,8 @@ fn cover_generic_impl_methods() {
     let mut analysis = SourceAnalysis::new();
     analysis.process_items(&parser.items, &ctx);
     let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
-    assert!(lines.cover.contains(&3));
-    assert!(lines.cover.contains(&4));
+    assert!(lines.is_force_covered(3));
+    assert!(lines.is_force_covered(4));
 
     let ctx = Context {
         config: &config,
@@ -806,7 +1240,7 @@ fn cover_generic_impl_methods() {
     let mut analysis = SourceAnalysis::new();
     analysis.process_items(&parser.items, &ctx);
     let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
-    assert!(lines.cover.contains(&5));
+    assert!(lines.is_force_covered(5));
 }
 
 #[test]
@@ -827,8 +1261,8 @@ fn cover_default_trait_methods() {
     let mut analysis = SourceAnalysis::new();
     analysis.process_items(&parser.items, &ctx);
     let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
-    assert!(lines.cover.contains(&2));
-    assert!(lines.cover.contains(&3));
+    assert!(lines.is_force_covered(2));
+    assert!(lines.is_force_covered(3));
 }
 
 #[test]
@@ -847,8 +1281,8 @@ fn cover_impl_trait_generic_fns() {
     let mut analysis = SourceAnalysis::new();
     analysis.process_items(&parser.items, &ctx);
     let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
-    assert!(lines.cover.contains(&1));
-    assert!(lines.cover.contains(&2));
+    assert!(lines.is_force_covered(1));
+    assert!(lines.is_force_covered(2));
 }
 
 #[test]
@@ -930,12 +1364,12 @@ fn include_inline_fns() {
     let mut analysis = SourceAnalysis::new();
     analysis.process_items(&parser.items, &ctx);
     let lines = analysis.get_line_analysis(ctx.file.to_path_buf());
-    assert!(!lines.cover.contains(&3));
-    assert!(lines.cover.contains(&4));
-    assert!(!lines.cover.contains(&5));
-    assert!(!lines.cover.contains(&6));
-    assert!(!lines.cover.contains(&7));
-    assert!(lines.cover.contains(&8));
+    assert!(!lines.is_force_covered(3));
+    assert!(lines.is_force_covered(4));
+    assert!(!lines.is_force_covered(5));
+    assert!(!lines.is_force_covered(6));
+    assert!(!lines.is_force_covered(7));
+    assert!(lines.is_force_covered(8));
 }
 
 #[test]
@@ -1691,8 +2125,8 @@ fn ignore_comment() {
             // and me as well
             x * 2
         }
-        
-        fn blah() 
+
+        fn blah()
         {
 
         }",
@@ -1726,9 +2160,9 @@ fn py_attr() {
                 println!(\"foo\");
                 Ok(())
             }
-            
+
             struct Blah;
-            
+
             #[pyimpl]
             impl Blah {
                 #[pyfunction]
@@ -1800,7 +2234,7 @@ fn module_nesting_correct() {
         #[cfg(test)]
         mod tests {
             mod inner; // should be at src/tests/inner.rs
-            
+
             mod foo {
                 mod innermost;
             }


### PR DESCRIPTION

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->

Fixes https://github.com/xd009642/tarpaulin/issues/1840

Force-covered generic fns reported the `{` line as uncovered:

    pub fn f<S>() -> bool {
        match true {
            _ => {          // <-- reported uncovered
                true
            }
        }
    }

LLVM emits no coverage region for the brace line when the pattern is inert (no binding), so force-cover flags it as a miss. Ignore the brace line (through the first statement) when the pattern is inert (wildcard, literal, or-of-literals, tuple-struct of inert sub- patterns, ...), there's no guard, and no sibling arm shares the line. Binding patterns (`a =>`, `Some(x) =>`) and guarded arms are left alone — they already get coverage regions.

~~`Pat::Ident` is conservatively treated as a binding even for unit variants like `None` — syn can't tell them from fresh bindings without type resolution.~~ (This is now decided with a heuristic: SCREAMING_CASE and CamelCase are existing idents, whereas snake_case is a name binding.)
