### PR TITLE
[report/html] Automatically set preferred theme

### DIFF
--- a/src/report/report_viewer.js
+++ b/src/report/report_viewer.js
@@ -302,6 +302,10 @@ function FileContent({file}) {
     },
   };
 
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+
   ReactDOM.render(e(App, {root, prevFilesMap}), document.getElementById('root'));
 
   const toggle = document.getElementById('theme-toggle');


### PR DESCRIPTION
Automatically sets the color scheme of the HTML report using the [`prefers-color-scheme`][1] CSS media feature. Defaults to light theme if no preference is set, which was the previous behavior.

I do not believe this will cause any breakages as [`Window.matchMedia()`][2] has been widely available since July 2015 and [`prefers-color-scheme`][1] has been widely available since January 2020.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme
[2]: https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia