### PR TITLE
Issue #1736

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,36 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
+            build-target: x86_64-unknown-linux-gnu.2.31
+            build-tool: cargo-zigbuild
             os: ubuntu-latest
           - target: x86_64-unknown-linux-musl
+            build-target: x86_64-unknown-linux-musl
+            build-tool: cargo
             os: ubuntu-latest
           - target: x86_64-apple-darwin
+            build-target: x86_64-apple-darwin
+            build-tool: cargo
             os: macos-latest
           - target: x86_64-pc-windows-msvc
+            build-target: x86_64-pc-windows-msvc
+            build-tool: cargo
             os: windows-latest
           - target: aarch64-unknown-linux-gnu
+            build-target: aarch64-unknown-linux-gnu.2.31
+            build-tool: cargo-zigbuild
             os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
+            build-target: aarch64-unknown-linux-musl
+            build-tool: cargo
             os: ubuntu-latest
           - target: aarch64-apple-darwin
+            build-target: aarch64-apple-darwin
+            build-tool: cargo
             os: macos-latest
           - target: universal-apple-darwin
+            build-target: universal-apple-darwin
+            build-tool: cargo
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +73,11 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cargo-tarpaulin
-          target: ${{ matrix.target }}
+          # Keep the public archive target stable for cargo-binstall while
+          # pinning GNU Linux artifacts to Debian bullseye's glibc floor.
+          archive: cargo-tarpaulin-${{ matrix.target }}
+          target: ${{ matrix.build-target }}
+          build-tool: ${{ matrix.build-tool }}
           features: vendored-openssl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -435,9 +435,10 @@ will speed up your CI runs.
 Alternatively, there are the prebuilt docker images or you can use
 [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
 
-The prebuilt binary is built using github actions ubuntu:latest image, because of this it
-doesn't work on xenial or trusty, but it works on bionic. You should still keep the rest
-of the recommended travis settings.
+The GNU Linux prebuilt binaries are built against glibc 2.31, matching Debian bullseye
+and Ubuntu 20.04. If you need to run on an older distribution, use the musl release
+artifact with `cargo-binstall --target x86_64-unknown-linux-musl` or install from
+source with `cargo install`.
 
 ### GitHub Actions
 


### PR DESCRIPTION
This is an attempt to solve the prebuilt binaries from cargo-binstall not working. But we'll see if it actually solves it when we publish...

<!--- When contributing to tarpaulin all contributions should branch off the -->
<!--- develop branch as master is only used for releases. --> 

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and them motivation below -->
