### PR TITLE
Quality: CoverageStat::Add catch-all silently discards second operand for mismatched variants

### DIFF
--- a/src/traces.rs
+++ b/src/traces.rs
@@ -48,7 +48,19 @@ impl Add for CoverageStat {
             (CoverageStat::Branch(ref l), CoverageStat::Branch(ref r)) => {
                 CoverageStat::Branch(l + r)
             }
-            t => t.0,
+            (CoverageStat::Condition(ref l), CoverageStat::Condition(ref r)) => {
+                let mut result = Vec::new();
+                for (ls, rs) in l.iter().zip(r.iter()) {
+                    result.push(ls + rs);
+                }
+                if l.len() > r.len() {
+                    result.extend_from_slice(&l[r.len()..]);
+                } else if r.len() > l.len() {
+                    result.extend_from_slice(&r[l.len()..]);
+                }
+                CoverageStat::Condition(result)
+            }
+            _ => panic!("Mismatched CoverageStat variants cannot be added"),
         }
     }
 }


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The `Add` implementation for `CoverageStat` has a catch-all match arm `t => t.0` that silently drops the second operand when adding mismatched variants (e.g., `Line + Branch`, `Condition + Line`, `Branch + Condition`). Since `CoverageStat` includes a `Condition` variant that has no merge logic at all, and the type is used throughout trace accumulation, mismatched additions would silently corrupt coverage data by discarding hits. This is a real data integrity bug if condition coverage is ever used alongside line/branch coverage.


**Severity**: `high`
**File**: `src/traces.rs`

### Solution
Replace the catch-all with an explicit arm that panics on mismatched types (programming error)
or explicitly handles all combinations:


### Changes
- `src/traces.rs` (modified)


 





---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1870